### PR TITLE
Add network rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(FastEngine)
 include(ExternalProject)
 
 #Fix compile error with minimp3
-if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-error=stringop-overflow=)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(FastEngine)
 include(ExternalProject)
 
 #Fix compile error with minimp3
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-error=stringop-overflow=)
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-error=stringop-overflow=)
+endif()
 
 #Check for architecture
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/includes/FastEngine/C_font.hpp
+++ b/includes/FastEngine/C_font.hpp
@@ -111,7 +111,7 @@ private:
     std::string g_name;
 };
 
-FGE_API fge::net::Packet& operator >>(fge::net::Packet& pck, fge::Font& data);
+FGE_API const fge::net::Packet& operator >>(const fge::net::Packet& pck, fge::Font& data);
 FGE_API fge::net::Packet& operator <<(fge::net::Packet& pck, const fge::Font& data);
 
 FGE_API void to_json(nlohmann::json& j, const fge::Font& p);

--- a/includes/FastEngine/C_object.hpp
+++ b/includes/FastEngine/C_object.hpp
@@ -168,6 +168,7 @@ public:
      * \param pck The packet where the object is unpacked
      */
     virtual void unpack(fge::net::Packet& pck);
+    //TODO: Apply network rules on every extraction method on every objects.
 
     /**
      * \brief Get the unique class name of the object

--- a/includes/FastEngine/C_packet.hpp
+++ b/includes/FastEngine/C_packet.hpp
@@ -65,25 +65,26 @@ public:
     void flush();
     void reserve(std::size_t reserveSize);
 
-    fge::net::Packet& append(std::size_t dsize); //Will push to host byte order without data (increasing size)
-    fge::net::Packet& append(const void* data, std::size_t dsize); //Will push to host byte order
-    fge::net::Packet& pack(const void* data, std::size_t dsize); //Will push and auto convert to network byte order
+    fge::net::Packet& append(std::size_t size); //Will push to host byte order without data (increasing size)
+    fge::net::Packet& append(const void* data, std::size_t size); //Will push to host byte order
+    fge::net::Packet& pack(const void* data, std::size_t size); //Will push and auto convert to network byte order
 
-    bool write(std::size_t pos, const void* data, std::size_t dsize); //Will write to host byte order
-    bool pack(std::size_t pos, const void* data, std::size_t dsize); //Will write and auto convert to network byte order
+    bool write(std::size_t pos, const void* data, std::size_t size); //Will write to host byte order
+    bool pack(std::size_t pos, const void* data, std::size_t size); //Will write and auto convert to network byte order
 
-    fge::net::Packet& read(void* buff, std::size_t bsize); //Will read to network byte order
-    fge::net::Packet& unpack(void* buff, std::size_t bsize); //Will read and auto convert to host byte order
+    fge::net::Packet& read(void* buff, std::size_t size); //Will read to network byte order
+    fge::net::Packet& unpack(void* buff, std::size_t size); //Will read and auto convert to host byte order
 
-    bool read(std::size_t pos, void* buff, std::size_t bsize) const; //Will read to network byte order
-    bool unpack(std::size_t pos, void* buff, std::size_t bsize) const; //Will read and auto convert to host byte order
+    bool read(std::size_t pos, void* buff, std::size_t size) const; //Will read to network byte order
+    bool unpack(std::size_t pos, void* buff, std::size_t size) const; //Will read and auto convert to host byte order
 
-    fge::net::Packet& shrink(std::size_t bsize);
-    bool erase(std::size_t pos, std::size_t dsize);
-    fge::net::Packet& skip(std::size_t dsize);
+    fge::net::Packet& shrink(std::size_t size);
+    bool erase(std::size_t pos, std::size_t size);
+    fge::net::Packet& skip(std::size_t size);
 
     void setReadPos(std::size_t pos);
     [[nodiscard]] std::size_t getReadPos() const;
+    [[nodiscard]] bool isExtractable(std::size_t size) const;
 
     [[nodiscard]] const uint8_t* getData(std::size_t pos) const; //Get data pointer to pos
     [[nodiscard]] uint8_t* getData(std::size_t pos);
@@ -94,7 +95,7 @@ public:
     [[nodiscard]] uint32_t getLength() const; //Get length of a string or others at the read position
                                 //can be useful to allocate a char buffer before reading
 
-    void setValidity(bool validity);
+    void setValidity(bool validity) const;
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] explicit operator bool() const;
     [[nodiscard]] bool endReached() const;
@@ -124,11 +125,11 @@ public:
 
     inline fge::net::Packet& operator <<(const fge::net::IpAddress& data);
 
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator <<(const std::forward_list<T>& data);
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator <<(const std::list<T>& data);
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator <<(const std::vector<T>& data);
 
     template<typename T>
@@ -167,11 +168,11 @@ public:
 
     inline fge::net::Packet& operator >>(fge::net::IpAddress& data);
 
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator >>(std::forward_list<T>& data);
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator >>(std::list<T>& data);
-    template <typename T>
+    template<typename T>
     fge::net::Packet& operator >>(std::vector<T>& data);
 
     template<typename T>
@@ -190,7 +191,7 @@ public:
     static std::size_t _defaultReserveSize;
 
     virtual void onSend(std::vector<uint8_t>& buffer, std::size_t offset);
-    virtual void onReceive(void* data, std::size_t dsize);
+    virtual void onReceive(void* data, std::size_t size);
 
 protected:
     friend class fge::net::SocketTcp;
@@ -202,7 +203,7 @@ protected:
 
     std::vector<uint8_t> _g_data;
     std::size_t _g_readPos;
-    bool _g_valid;
+    mutable bool _g_valid;
 };
 
 }//end net

--- a/includes/FastEngine/C_packet.hpp
+++ b/includes/FastEngine/C_packet.hpp
@@ -72,17 +72,17 @@ public:
     bool write(std::size_t pos, const void* data, std::size_t size); //Will write to host byte order
     bool pack(std::size_t pos, const void* data, std::size_t size); //Will write and auto convert to network byte order
 
-    fge::net::Packet& read(void* buff, std::size_t size); //Will read to network byte order
-    fge::net::Packet& unpack(void* buff, std::size_t size); //Will read and auto convert to host byte order
+    const fge::net::Packet& read(void* buff, std::size_t size) const; //Will read to network byte order
+    const fge::net::Packet& unpack(void* buff, std::size_t size) const; //Will read and auto convert to host byte order
 
     bool read(std::size_t pos, void* buff, std::size_t size) const; //Will read to network byte order
     bool unpack(std::size_t pos, void* buff, std::size_t size) const; //Will read and auto convert to host byte order
 
     fge::net::Packet& shrink(std::size_t size);
     bool erase(std::size_t pos, std::size_t size);
-    fge::net::Packet& skip(std::size_t size);
+    const fge::net::Packet& skip(std::size_t size) const;
 
-    void setReadPos(std::size_t pos);
+    void setReadPos(std::size_t pos) const;
     [[nodiscard]] std::size_t getReadPos() const;
     [[nodiscard]] bool isExtractable(std::size_t size) const;
 
@@ -94,7 +94,7 @@ public:
     [[nodiscard]] std::size_t getDataSize() const;
     [[nodiscard]] uint32_t getLength() const; //Get length of a string or others at the read position
                                 //can be useful to allocate a char buffer before reading
-
+    void invalidate() const;
     void setValidity(bool validity) const;
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] explicit operator bool() const;
@@ -144,46 +144,46 @@ public:
 
     ///
 
-    inline fge::net::Packet& operator >>(bool& data);
+    inline const fge::net::Packet& operator >>(bool& data) const;
 
-    inline fge::net::Packet& operator >>(int8_t& data);
-    inline fge::net::Packet& operator >>(int16_t& data);
-    inline fge::net::Packet& operator >>(int32_t& data);
-    inline fge::net::Packet& operator >>(int64_t& data);
+    inline const fge::net::Packet& operator >>(int8_t& data) const;
+    inline const fge::net::Packet& operator >>(int16_t& data) const;
+    inline const fge::net::Packet& operator >>(int32_t& data) const;
+    inline const fge::net::Packet& operator >>(int64_t& data) const;
 
-    inline fge::net::Packet& operator >>(uint8_t& data);
-    inline fge::net::Packet& operator >>(uint16_t& data);
-    inline fge::net::Packet& operator >>(uint32_t& data);
-    inline fge::net::Packet& operator >>(uint64_t& data);
+    inline const fge::net::Packet& operator >>(uint8_t& data) const;
+    inline const fge::net::Packet& operator >>(uint16_t& data) const;
+    inline const fge::net::Packet& operator >>(uint32_t& data) const;
+    inline const fge::net::Packet& operator >>(uint64_t& data) const;
 
-    inline fge::net::Packet& operator >>(float& data);
-    inline fge::net::Packet& operator >>(double& data);
-    inline fge::net::Packet& operator >>(long double& data);
+    inline const fge::net::Packet& operator >>(float& data) const;
+    inline const fge::net::Packet& operator >>(double& data) const;
+    inline const fge::net::Packet& operator >>(long double& data) const;
 
-    fge::net::Packet& operator >>(char* data);
-    fge::net::Packet& operator >>(std::string& data);
-    fge::net::Packet& operator >>(wchar_t* data);
-    fge::net::Packet& operator >>(std::wstring& data);
-    fge::net::Packet& operator >>(sf::String& data);
+    const fge::net::Packet& operator >>(char* data) const;
+    const fge::net::Packet& operator >>(std::string& data) const;
+    const fge::net::Packet& operator >>(wchar_t* data) const;
+    const fge::net::Packet& operator >>(std::wstring& data) const;
+    const fge::net::Packet& operator >>(sf::String& data) const;
 
-    inline fge::net::Packet& operator >>(fge::net::IpAddress& data);
-
-    template<typename T>
-    fge::net::Packet& operator >>(std::forward_list<T>& data);
-    template<typename T>
-    fge::net::Packet& operator >>(std::list<T>& data);
-    template<typename T>
-    fge::net::Packet& operator >>(std::vector<T>& data);
+    inline const fge::net::Packet& operator >>(fge::net::IpAddress& data) const;
 
     template<typename T>
-    fge::net::Packet& operator >>(sf::Vector2<T>& data);
+    const fge::net::Packet& operator >>(std::forward_list<T>& data) const;
     template<typename T>
-    fge::net::Packet& operator >>(sf::Vector3<T>& data);
+    const fge::net::Packet& operator >>(std::list<T>& data) const;
+    template<typename T>
+    const fge::net::Packet& operator >>(std::vector<T>& data) const;
 
     template<typename T>
-    fge::net::Packet& operator >>(fge::Matrix<T>& data);
+    const fge::net::Packet& operator >>(sf::Vector2<T>& data) const;
+    template<typename T>
+    const fge::net::Packet& operator >>(sf::Vector3<T>& data) const;
 
-    inline fge::net::Packet& operator >>(sf::Color& data);
+    template<typename T>
+    const fge::net::Packet& operator >>(fge::Matrix<T>& data) const;
+
+    inline const fge::net::Packet& operator >>(sf::Color& data) const;
 
     bool operator ==(const Packet& right) const = delete;
     bool operator !=(const Packet& right) const = delete;
@@ -202,7 +202,7 @@ protected:
     bool _g_lastDataValidity;
 
     std::vector<uint8_t> _g_data;
-    std::size_t _g_readPos;
+    mutable std::size_t _g_readPos;
     mutable bool _g_valid;
 };
 

--- a/includes/FastEngine/C_packet.inl
+++ b/includes/FastEngine/C_packet.inl
@@ -141,7 +141,7 @@ fge::net::Packet& Packet::operator <<(const fge::net::IpAddress& data)
 
 ///
 
-fge::net::Packet& Packet::operator >>(bool& data)
+const fge::net::Packet& Packet::operator >>(bool& data) const
 {
     uint8_t a;
     this->read(&a, sizeof(uint8_t));
@@ -149,55 +149,55 @@ fge::net::Packet& Packet::operator >>(bool& data)
     return *this;
 }
 
-fge::net::Packet& Packet::operator >>(int8_t& data)
+const fge::net::Packet& Packet::operator >>(int8_t& data) const
 {
     return this->read(&data, sizeof(int8_t));
 }
-fge::net::Packet& Packet::operator >>(int16_t& data)
+const fge::net::Packet& Packet::operator >>(int16_t& data) const
 {
     return this->unpack(&data, sizeof(int16_t));
 }
-fge::net::Packet& Packet::operator >>(int32_t& data)
+const fge::net::Packet& Packet::operator >>(int32_t& data) const
 {
     return this->unpack(&data, sizeof(int32_t));
 }
-fge::net::Packet& Packet::operator >>(int64_t& data)
+const fge::net::Packet& Packet::operator >>(int64_t& data) const
 {
     return this->unpack(&data, sizeof(int64_t));
 }
 
-fge::net::Packet& Packet::operator >>(uint8_t& data)
+const fge::net::Packet& Packet::operator >>(uint8_t& data) const
 {
     return this->read(&data, sizeof(uint8_t));
 }
-fge::net::Packet& Packet::operator >>(uint16_t& data)
+const fge::net::Packet& Packet::operator >>(uint16_t& data) const
 {
     return this->unpack(&data, sizeof(uint16_t));
 }
-fge::net::Packet& Packet::operator >>(uint32_t& data)
+const fge::net::Packet& Packet::operator >>(uint32_t& data) const
 {
     return this->unpack(&data, sizeof(uint32_t));
 }
-fge::net::Packet& Packet::operator >>(uint64_t& data)
+const fge::net::Packet& Packet::operator >>(uint64_t& data) const
 {
     return this->unpack(&data, sizeof(uint64_t));
 }
 
-fge::net::Packet& Packet::operator >>(float& data)
+const fge::net::Packet& Packet::operator >>(float& data) const
 {
     return this->unpack(&data, sizeof(float));
 }
-fge::net::Packet& Packet::operator >>(double& data)
+const fge::net::Packet& Packet::operator >>(double& data) const
 {
     return this->unpack(&data, sizeof(double));
 }
-fge::net::Packet& Packet::operator >>(long double& data)
+const fge::net::Packet& Packet::operator >>(long double& data) const
 {
     return this->unpack(&data, sizeof(long double));
 }
 
 template <typename T>
-fge::net::Packet& Packet::operator >>(std::forward_list<T>& data)
+const fge::net::Packet& Packet::operator >>(std::forward_list<T>& data) const
 {
     fge::net::SizeType length = 0;
     *this >> length;
@@ -213,7 +213,7 @@ fge::net::Packet& Packet::operator >>(std::forward_list<T>& data)
     return *this;
 }
 template <typename T>
-fge::net::Packet& Packet::operator >>(std::list<T>& data)
+const fge::net::Packet& Packet::operator >>(std::list<T>& data) const
 {
     fge::net::SizeType length = 0;
     *this >> length;
@@ -229,7 +229,7 @@ fge::net::Packet& Packet::operator >>(std::list<T>& data)
     return *this;
 }
 template <typename T>
-fge::net::Packet& Packet::operator >>(std::vector<T>& data)
+const fge::net::Packet& Packet::operator >>(std::vector<T>& data) const
 {
     fge::net::SizeType length = 0;
     *this >> length;
@@ -244,18 +244,18 @@ fge::net::Packet& Packet::operator >>(std::vector<T>& data)
 }
 
 template<typename T>
-fge::net::Packet& Packet::operator >>(sf::Vector2<T>& data)
+const fge::net::Packet& Packet::operator >>(sf::Vector2<T>& data) const
 {
     return *this >> data.x >> data.y;
 }
 template<typename T>
-fge::net::Packet& Packet::operator >>(sf::Vector3<T>& data)
+const fge::net::Packet& Packet::operator >>(sf::Vector3<T>& data) const
 {
     return *this >> data.x >> data.y >> data.z;
 }
 
 template<typename T>
-fge::net::Packet& Packet::operator >>(fge::Matrix<T>& data)
+const fge::net::Packet& Packet::operator >>(fge::Matrix<T>& data) const
 {
     fge::net::SizeType sizeX=0, sizeY=0;
     *this >> sizeX >> sizeY;
@@ -272,7 +272,7 @@ fge::net::Packet& Packet::operator >>(fge::Matrix<T>& data)
     return *this;
 }
 
-fge::net::Packet& Packet::operator >>(sf::Color& data)
+const fge::net::Packet& Packet::operator >>(sf::Color& data) const
 {
     uint32_t buff;
     *this >> buff;
@@ -280,7 +280,7 @@ fge::net::Packet& Packet::operator >>(sf::Color& data)
     return *this;
 }
 
-fge::net::Packet& Packet::operator >>(fge::net::IpAddress& data)
+const fge::net::Packet& Packet::operator >>(fge::net::IpAddress& data) const
 {
     uint32_t ip=0;
     this->read(&ip, sizeof(uint32_t) );

--- a/includes/FastEngine/C_scene.hpp
+++ b/includes/FastEngine/C_scene.hpp
@@ -42,6 +42,8 @@
 #define FGE_SCENE_BAD_PLANDEPTH std::numeric_limits<fge::ObjectPlanDepth>::max()
 #define FGE_SCENE_BAD_PLAN std::numeric_limits<fge::ObjectPlan>::max()
 
+#define FGE_SCENE_LIMIT_NAMESIZE 200
+
 #define FGE_NEWOBJECT(objectType_, objectArgs_ ...) std::unique_ptr<fge::Object>{new objectType_{objectArgs_}}
 #define FGE_NEWOBJECT_PTR(objectPtr_) std::unique_ptr<fge::Object>{objectPtr_}
 
@@ -83,7 +85,9 @@ struct SceneNetEvent
         SEVT_DELOBJECT = 0,
         SEVT_NEWOBJECT,
 
-        SEVT_UNKNOWN
+        SEVT_UNKNOWN,
+
+        SEVT_MAX_
     };
 
     fge::SceneNetEvent::Events _event;
@@ -101,7 +105,9 @@ enum ObjectType : uint8_t
 
     TYPE_OBJECT,
     TYPE_DECAY,
-    TYPE_GUI
+    TYPE_GUI,
+
+    TYPE_MAX_
 };
 
 /**
@@ -403,7 +409,10 @@ public:
      */
     inline void setName(std::string name)
     {
-        this->g_name = std::move(name);
+        if (name.size() <= FGE_SCENE_LIMIT_NAMESIZE)
+        {
+            this->g_name = std::move(name);
+        }
     }
 
     /**

--- a/includes/FastEngine/C_texture.hpp
+++ b/includes/FastEngine/C_texture.hpp
@@ -122,7 +122,7 @@ private:
     std::string g_name;
 };
 
-FGE_API fge::net::Packet& operator >>(fge::net::Packet& pck, fge::Texture& data);
+FGE_API const fge::net::Packet& operator >>(const fge::net::Packet& pck, fge::Texture& data);
 FGE_API fge::net::Packet& operator <<(fge::net::Packet& pck, const fge::Texture& data);
 
 FGE_API void to_json(nlohmann::json& j, const fge::Texture& p);

--- a/includes/FastEngine/extra_string.hpp
+++ b/includes/FastEngine/extra_string.hpp
@@ -34,6 +34,15 @@ namespace string
 
 /**
  * \ingroup extraString
+ * \brief Check if the provided string has valid utf8 encoded chars
+ *
+ * \param str The string to check
+ * \return \b True if the string is valid, \b False otherwise
+ */
+FGE_API bool IsValidUtf8String(const std::string& str);
+
+/**
+ * \ingroup extraString
  * \brief Convert efficiently a string to an uint8_t
  *
  * \param str The string to convert

--- a/includes/FastEngine/fastengine_extern.hpp
+++ b/includes/FastEngine/fastengine_extern.hpp
@@ -36,6 +36,12 @@
  * \defgroup network Network
  * \brief Everything related to network
  *
+ * \defgroup networkRules Network rules
+ * \brief Everything related to network rules
+ *
+ * Network rules are utilities that make sure that the data inside of a packet is
+ * valid before extracting and using it.
+ *
  * \defgroup utility Utility/Tools
  * \brief Everything related to some utility/tools
  *

--- a/includes/FastEngine/network_manager.hpp
+++ b/includes/FastEngine/network_manager.hpp
@@ -26,41 +26,172 @@
 
 #define FGE_NET_BAD_HEADER 0
 
+/**
+ * \ingroup networkRules
+ * @{
+ */
+
+/**
+ * \brief Macro that indicate the beginning of a network rules chain
+ *
+ * This will create a scope and a ChainedArguments variable.
+ */
 #define FGE_NET_RULES_START {auto chainedArgs_=
+/**
+ * \brief Macro that will check extract the ChainedArguments
+ *
+ * \see fge::net::rules::ChainedArguments::checkExtract
+ */
 #define FGE_NET_RULES_CHECK_EXTRACT chainedArgs_.checkExtract()
+/**
+ * \brief Macro that will check is everything is valid and return if not
+ */
 #define FGE_NET_RULES_TRY if (!FGE_NET_RULES_CHECK_EXTRACT) {return;}
+/**
+ * \brief Macro that will check is everything is valid and do something else instead
+ *
+ * \param else_ The code that will be executed when rules is invalid
+ */
 #define FGE_NET_RULES_TRY_ELSE(else_) if (!FGE_NET_RULES_CHECK_EXTRACT) {else_}
+/**
+ * \brief Macro that will get the value stored in the ChainedArguments and move it
+ */
 #define FGE_NET_RULES_RESULT std::move(chainedArgs_._value.value())
+/**
+ * \brief Macro that will get the value stored in the ChainedArguments
+ */
 #define FGE_NET_RULES_RESULT_N chainedArgs_._value.value()
+/**
+ * \brief Macro that will made everything in order to affect the ChainedArguments value into the provided variable
+ *
+ * This macro will first check if the packet is valid after Packet extraction and will
+ * copy or move the value into the provided variable.
+ *
+ * \param var_ The variable that will receive the valid value
+ */
 #define FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_TRY if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
+/**
+ * \brief Macro that will made everything in order to affect the ChainedArguments value into the provided function/method
+ *
+ * \see FGE_NET_RULES_AFFECT
+ *
+ * \param setter_ The function to be called in order to affect the valid value
+ */
 #define FGE_NET_RULES_SETTER(setter_) FGE_NET_RULES_TRY setter_(FGE_NET_RULES_RESULT);
+/**
+ * \brief Same as FGE_NET_RULES_AFFECT with custom \b else condition
+ *
+ * \see FGE_NET_RULES_AFFECT
+ *
+ * \param var_ The variable that will receive the valid value
+ * \param else_ The code that will be executed when rules is invalid
+ */
 #define FGE_NET_RULES_AFFECT_ELSE(var_, else_) FGE_NET_RULES_TRY_ELSE(else_) if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
+/**
+ * \brief Same as FGE_NET_RULES_SETTER with custom \b else condition
+ *
+ * \see FGE_NET_RULES_AFFECT
+ *
+ * \param setter_ The function to be called in order to affect the valid value
+ * \param else_ The code that will be executed when rules is invalid
+ */
 #define FGE_NET_RULES_SETTER_ELSE(setter_, else_) FGE_NET_RULES_TRY_ELSE(else_) setter_(FGE_NET_RULES_RESULT);
+/**
+ * \brief End the rules scope
+ */
 #define FGE_NET_RULES_END }
 #define FGE_NET_RULES_AFFECT_END(var_) FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_END
 #define FGE_NET_RULES_SETTER_END(setter_) FGE_NET_RULES_SETTER(setter_) FGE_NET_RULES_END
 #define FGE_NET_RULES_AFFECT_END_ELSE(var_, else_) FGE_NET_RULES_AFFECT_ELSE(var_, else_) FGE_NET_RULES_END
 #define FGE_NET_RULES_SETTER_END_ELSE(setter_, else_) FGE_NET_RULES_SETTER_ELSE(setter_, else_) FGE_NET_RULES_END
+/**
+ * @}
+ */
 
 namespace fge::net
 {
 
+/**
+ * \ingroup network
+ * @{
+ */
+
+/**
+ * \typedef PacketHeader
+ * \brief Simple aliased type for packets header, useful to differentiate multiple network actions
+ */
 using PacketHeader = uint16_t;
 
+/**
+ * \brief Get a basic scene checksum
+ *
+ * The checksum is computed with every ObjectSid.
+ *
+ * \param scene The scene
+ * \return A 32bit checksum value
+ */
 FGE_API uint32_t GetSceneChecksum(fge::Scene& scene);
 
+/**
+ * \brief Utility function to write packet data into a file
+ *
+ * \param pck The Packet
+ * \param file The file path that will contain the data
+ * \return \b true if no error, \b false otherwise
+ */
 FGE_API bool WritePacketDataToFile(fge::net::Packet& pck, const std::string& file);
 
-
+/**
+ * \brief Shortcut function that will clear the Packet and write an header to it
+ *
+ * \param pck The Packet
+ * \param header The header that will be written
+ * \return A reference to the same Packet
+ */
 inline fge::net::Packet& SetHeader(fge::net::Packet& pck, fge::net::PacketHeader header);
+/**
+ * \brief Shortcut function that will retrieve the received Packet header
+ *
+ * \param pck The Packet
+ * \return A packet header
+ */
 inline fge::net::PacketHeader GetHeader(fge::net::Packet& pck);
 
+/**
+ * \brief Shortcut function that will extract and compare the provided skey
+ *
+ * \param pck The Packet
+ * \param skey An skey that will be compared
+ * \return \b true if the skey is the same and the packet is valid, \b false otherwise
+ */
 inline bool CheckSkey(fge::net::Packet& pck, fge::net::Skey skey);
+/**
+ * \brief Shortcut function that will extract the skey
+ *
+ * \param pck The Packet
+ * \return The extracted skey
+ */
 inline fge::net::Skey GetSkey(fge::net::Packet& pck);
+
+/**
+ * @}
+ */
 
 namespace rules
 {
 
+/**
+ * \struct ChainedArguments
+ * \brief This is a wrapper around a Packet with an optional value
+ * \ingroup networkRules
+ *
+ * This structure go through a rules chain and avoid extracting multiple times
+ * the required value.
+ *
+ * When a rule is invalid, it will invalidate the Packet.
+ *
+ * \tparam TValue The type of the value that will be extracted
+ */
 template<class TValue>
 struct ChainedArguments
 {
@@ -72,45 +203,139 @@ struct ChainedArguments
             _pck(pck)
     {}
 
-    const fge::net::Packet* _pck;
+    const fge::net::Packet* _pck; ///< This should be never null
     std::optional<TValue> _value{std::nullopt};
 
+    /**
+     * \brief Make sure that the value is extracted and return \b true if everything is valid
+     *
+     * \return The validity of the Packet
+     */
     bool checkExtract();
+    /**
+     * \brief Make sure that the value is extracted and return the extracted value
+     *
+     * \return The extracted value
+     */
     TValue& extract();
+    /**
+     * \brief Peek without changing the read position a certain value
+     *
+     * \tparam TPeek The type of the value that will be peeked
+     * \return A copy of the peeked value
+     */
     template<class TPeek>
     TPeek peek();
 };
 
-template<class TValue>
-bool CheckExtract(fge::net::rules::ChainedArguments<TValue>& args);
-template<class TValue>
-TValue& Extract(fge::net::rules::ChainedArguments<TValue>& args);
-template<class TValue>
-TValue Peek(fge::net::rules::ChainedArguments<TValue>& args);
+/**
+ * \ingroup networkRules
+ * @{
+ */
 
+/**
+ * \brief Range rule, check if the value is in the min/max range
+ *
+ * The comparison is not strict for min/max.
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param min The minimum range
+ * \param max The maximum range
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RRange(const TValue& min, const TValue& max, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Must equal rule, check if the value is equal to the provided one
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param a The value that will be compared
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RMustEqual(const TValue& a, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Strict less rule, check if the value is strictly lesser than the provided one
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param less The value that will be compared
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RStrictLess(TValue less, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Less rule, check if the value is lesser than the provided one
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param less The value that will be compared
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RLess(TValue less, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Size range rule, check if the size is in the min/max range
+ *
+ * This function will peek the current fge::net::SizeType at read pos.
+ * It is useful to apply rules on the size of something (string, container, ...) before
+ * extracting it.
+ *
+ * The actual value will not be extracted here.
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param min The minimum range
+ * \param max The maximum range
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RSizeRange(fge::net::SizeType min, fge::net::SizeType max, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Size must equal rule, check if the size is equal to the provided one
+ *
+ * \see RSizeRange
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param a The value that will be compared
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RSizeMustEqual(fge::net::SizeType a, fge::net::rules::ChainedArguments<TValue> args);
 
+/**
+ * \brief Check if the extracted string is a valid UTF8 string
+ *
+ * This function will extract the string, make sure that you apply size rules
+ * before in order to avoid bad extraction.
+ *
+ * \tparam TValue The type of the value
+ * \tparam TInvertResult Invert the result of the rule
+ * \param args The chained argument
+ * \return The chained argument
+ */
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RMustValidUtf8(fge::net::rules::ChainedArguments<TValue> args);
 
-}//end rules
+/**
+ * @}
+ */
 
+}//end rules
 }//end fge::net
 
 #include <FastEngine/network_manager.inl>

--- a/includes/FastEngine/network_manager.hpp
+++ b/includes/FastEngine/network_manager.hpp
@@ -27,10 +27,11 @@
 #define FGE_NET_BAD_HEADER 0
 
 #define FGE_NET_RULES_START {auto chainedArgs_=
-#define FGE_NET_RULES_TRY if (!chainedArgs_._pck->isValid()) {return;}
-#define FGE_NET_RULES_TRY_ELSE(else_) if (!chainedArgs_._pck->isValid()) {else_}
-#define FGE_NET_RULES_RESULT std::move(fge::net::rules::Extract(chainedArgs_))
-#define FGE_NET_RULES_RESULT_N fge::net::rules::Extract(chainedArgs_)
+#define FGE_NET_RULES_EXTRACT fge::net::rules::Extract(chainedArgs_);
+#define FGE_NET_RULES_TRY if (!chainedArgs_._pck->isValid()) {return;} FGE_NET_RULES_EXTRACT if (!chainedArgs_._pck->isValid()) {return;}
+#define FGE_NET_RULES_TRY_ELSE(else_) if (!chainedArgs_._pck->isValid()) {else_} FGE_NET_RULES_EXTRACT if (!chainedArgs_._pck->isValid()) {else_}
+#define FGE_NET_RULES_RESULT std::move(chainedArgs_._value.value())
+#define FGE_NET_RULES_RESULT_N chainedArgs_._value.value()
 #define FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_TRY if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
 #define FGE_NET_RULES_SETTER(setter_) FGE_NET_RULES_TRY setter_(FGE_NET_RULES_RESULT);
 #define FGE_NET_RULES_AFFECT_ELSE(var_, else_) FGE_NET_RULES_TRY_ELSE(else_) if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
@@ -61,16 +62,19 @@ namespace rules
 {
 
 template<class TValue>
-struct ChainedArguments
-{
-    fge::net::Packet* _pck;
-    std::optional<TValue> _value{std::nullopt};
-};
+struct ChainedArguments;
 
 template<class TValue>
 TValue& Extract(fge::net::rules::ChainedArguments<TValue>& args);
 template<class TValue>
 TValue Peek(fge::net::rules::ChainedArguments<TValue>& args);
+
+template<class TValue>
+struct ChainedArguments
+{
+    fge::net::Packet* _pck;
+    std::optional<TValue> _value{std::nullopt};
+};
 
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RRange(const TValue& min, const TValue& max, fge::net::rules::ChainedArguments<TValue> args);

--- a/includes/FastEngine/network_manager.hpp
+++ b/includes/FastEngine/network_manager.hpp
@@ -22,6 +22,7 @@
 #include <FastEngine/C_object.hpp>
 #include <FastEngine/C_packet.hpp>
 #include <FastEngine/C_client.hpp>
+#include <optional>
 
 #define FGE_NET_BAD_HEADER 0
 #define FGE_NET_RULES_START {auto chainedArgs_=

--- a/includes/FastEngine/network_manager.hpp
+++ b/includes/FastEngine/network_manager.hpp
@@ -25,15 +25,21 @@
 #include <optional>
 
 #define FGE_NET_BAD_HEADER 0
+
 #define FGE_NET_RULES_START {auto chainedArgs_=
 #define FGE_NET_RULES_TRY if (!chainedArgs_._pck->isValid()) {return;}
-#define FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_TRY if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = std::move(chainedArgs_._value.value());}else{(var_) = chainedArgs_._value.value();}
-#define FGE_NET_RULES_AFFECT_SETTER(setter_) FGE_NET_RULES_TRY setter_(std::move(chainedArgs_._value.value()));
-#define FGE_NET_RULES_RESULT std::move(chainedArgs_._value.value())
-#define FGE_NET_RULES_RESULT_N chainedArgs_._value.value()
+#define FGE_NET_RULES_TRY_ELSE(else_) if (!chainedArgs_._pck->isValid()) {else_}
+#define FGE_NET_RULES_RESULT std::move(fge::net::rules::Extract(chainedArgs_))
+#define FGE_NET_RULES_RESULT_N fge::net::rules::Extract(chainedArgs_)
+#define FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_TRY if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
+#define FGE_NET_RULES_SETTER(setter_) FGE_NET_RULES_TRY setter_(FGE_NET_RULES_RESULT);
+#define FGE_NET_RULES_AFFECT_ELSE(var_, else_) FGE_NET_RULES_TRY_ELSE(else_) if constexpr (std::is_move_constructible<decltype(var_)>::value){(var_) = FGE_NET_RULES_RESULT;}else{(var_) = FGE_NET_RULES_RESULT_N;}
+#define FGE_NET_RULES_SETTER_ELSE(setter_, else_) FGE_NET_RULES_TRY_ELSE(else_) setter_(FGE_NET_RULES_RESULT);
 #define FGE_NET_RULES_END }
 #define FGE_NET_RULES_AFFECT_END(var_) FGE_NET_RULES_AFFECT(var_) FGE_NET_RULES_END
-#define FGE_NET_RULES_AFFECT_SETTER_END(setter_) FGE_NET_RULES_AFFECT_SETTER(setter_) FGE_NET_RULES_END
+#define FGE_NET_RULES_SETTER_END(setter_) FGE_NET_RULES_SETTER(setter_) FGE_NET_RULES_END
+#define FGE_NET_RULES_AFFECT_END_ELSE(var_, else_) FGE_NET_RULES_AFFECT_ELSE(var_, else_) FGE_NET_RULES_END
+#define FGE_NET_RULES_SETTER_END_ELSE(setter_, else_) FGE_NET_RULES_SETTER_ELSE(setter_, else_) FGE_NET_RULES_END
 
 namespace fge::net
 {
@@ -63,12 +69,23 @@ struct ChainedArguments
 
 template<class TValue>
 TValue& Extract(fge::net::rules::ChainedArguments<TValue>& args);
+template<class TValue>
+TValue Peek(fge::net::rules::ChainedArguments<TValue>& args);
 
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RRange(const TValue& min, const TValue& max, fge::net::rules::ChainedArguments<TValue> args);
 
 template<class TValue, bool TInvertResult=false>
 fge::net::rules::ChainedArguments<TValue> RMustEqual(const TValue& a, fge::net::rules::ChainedArguments<TValue> args);
+
+template<class TValue, bool TInvertResult=false>
+fge::net::rules::ChainedArguments<TValue> RSizeRange(fge::net::SizeType min, fge::net::SizeType max, fge::net::rules::ChainedArguments<TValue> args);
+
+template<class TValue, bool TInvertResult=false>
+fge::net::rules::ChainedArguments<TValue> RSizeMustEqual(fge::net::SizeType a, fge::net::rules::ChainedArguments<TValue> args);
+
+template<class TValue, bool TInvertResult=false>
+fge::net::rules::ChainedArguments<TValue> RMustValidUtf8(fge::net::rules::ChainedArguments<TValue> args);
 
 }//end rules
 

--- a/includes/FastEngine/network_manager.inl
+++ b/includes/FastEngine/network_manager.inl
@@ -78,12 +78,13 @@ fge::net::rules::ChainedArguments<TValue> RRange(const TValue& min, const TValue
     if (args._pck->isValid())
     {
         auto& val = Extract<TValue>(args);
-
-        if ( (val >= min && val <= max) ^ TInvertResult )
+        if (args._pck->isValid())
         {
-            return std::move(args);
+            if ( !((val >= min && val <= max) ^ TInvertResult) )
+            {
+                args._pck->setValidity(false);
+            }
         }
-        args._pck->setValidity(false);
     }
     return std::move(args);
 }
@@ -94,12 +95,13 @@ fge::net::rules::ChainedArguments<TValue> RMustEqual(const TValue& a, fge::net::
     if (args._pck->isValid())
     {
         auto& val = Extract<TValue>(args);
-
-        if ( (val == a) ^ TInvertResult )
+        if (args._pck->isValid())
         {
-            return std::move(args);
+            if ( !((val == a) ^ TInvertResult) )
+            {
+                args._pck->setValidity(false);
+            }
         }
-        args._pck->setValidity(false);
     }
     return std::move(args);
 }
@@ -110,12 +112,13 @@ fge::net::rules::ChainedArguments<TValue> RSizeRange(fge::net::SizeType min, fge
     if (args._pck->isValid())
     {
         fge::net::SizeType val = Peek<fge::net::SizeType>(args);
-
-        if ( (val >= min && val <= max) ^ TInvertResult )
+        if (args._pck->isValid())
         {
-            return std::move(args);
+            if ( !((val >= min && val <= max) ^ TInvertResult) )
+            {
+                args._pck->setValidity(false);
+            }
         }
-        args._pck->setValidity(false);
     }
     return std::move(args);
 }
@@ -126,12 +129,13 @@ fge::net::rules::ChainedArguments<TValue> RSizeMustEqual(fge::net::SizeType a, f
     if (args._pck->isValid())
     {
         fge::net::SizeType val = Peek<fge::net::SizeType>(args);
-
-        if ( (val == a) ^ TInvertResult )
+        if (args._pck->isValid())
         {
-            return std::move(args);
+            if ( !((val == a) ^ TInvertResult) )
+            {
+                args._pck->setValidity(false);
+            }
         }
-        args._pck->setValidity(false);
     }
     return std::move(args);
 }
@@ -142,12 +146,13 @@ fge::net::rules::ChainedArguments<TValue> RMustValidUtf8(fge::net::rules::Chaine
     if (args._pck->isValid())
     {
         auto& val = Extract<TValue>(args);
-
-        if ( fge::string::IsValidUtf8String(val) ^ TInvertResult )
+        if (args._pck->isValid())
         {
-            return std::move(args);
+            if ( !(fge::string::IsValidUtf8String(val) ^ TInvertResult) )
+            {
+                args._pck->setValidity(false);
+            }
         }
-        args._pck->setValidity(false);
     }
     return std::move(args);
 }

--- a/sources/C_font.cpp
+++ b/sources/C_font.cpp
@@ -98,7 +98,7 @@ Font::operator const sf::Font&() const
     return *this->g_data->_font;
 }
 
-fge::net::Packet& operator >>(fge::net::Packet& pck, fge::Font& data)
+const fge::net::Packet& operator >>(const fge::net::Packet& pck, fge::Font& data)
 {
     std::string fontName;
     pck >> fontName;

--- a/sources/C_packet.cpp
+++ b/sources/C_packet.cpp
@@ -188,7 +188,7 @@ bool Packet::pack(std::size_t pos, const void* data, std::size_t size)
     return false;
 }
 
-fge::net::Packet& Packet::read(void* buff, std::size_t size)
+const fge::net::Packet& Packet::read(void* buff, std::size_t size) const
 {
     if (buff && (size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
@@ -204,7 +204,7 @@ fge::net::Packet& Packet::read(void* buff, std::size_t size)
     this->_g_valid = false;
     return *this;
 }
-fge::net::Packet& Packet::unpack(void* buff, std::size_t size)
+const fge::net::Packet& Packet::unpack(void* buff, std::size_t size) const
 {
     if (buff && (size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
@@ -297,7 +297,7 @@ bool Packet::erase(std::size_t pos, std::size_t size)
     }
     return false;
 }
-fge::net::Packet& Packet::skip(std::size_t size)
+const fge::net::Packet& Packet::skip(std::size_t size) const
 {
     if ((size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
@@ -309,7 +309,7 @@ fge::net::Packet& Packet::skip(std::size_t size)
     return *this;
 }
 
-void Packet::setReadPos(std::size_t pos)
+void Packet::setReadPos(std::size_t pos) const
 {
     this->_g_readPos = (pos>this->_g_data.size()) ? this->_g_data.size() : pos;
 }
@@ -350,6 +350,10 @@ uint32_t Packet::getLength() const
     return result;
 }
 
+void Packet::invalidate() const
+{
+    this->_g_valid = false;
+}
 void Packet::setValidity(bool validity) const
 {
     this->_g_valid = validity;
@@ -430,7 +434,7 @@ fge::net::Packet& Packet::operator <<(const sf::String& data)
     return *this;
 }
 
-fge::net::Packet& Packet::operator >>(char* data)
+const fge::net::Packet& Packet::operator >>(char* data) const
 {
     fge::net::SizeType length = 0;
     this->unpack(&length, sizeof(length));
@@ -453,7 +457,7 @@ fge::net::Packet& Packet::operator >>(char* data)
     }
     return *this;
 }
-fge::net::Packet& Packet::operator >>(std::string& data)
+const fge::net::Packet& Packet::operator >>(std::string& data) const
 {
     fge::net::SizeType length = 0;
     this->unpack(&length, sizeof(length));
@@ -463,7 +467,7 @@ fge::net::Packet& Packet::operator >>(std::string& data)
         if ((this->_g_readPos + length - 1) < this->_g_data.size())
         {
             data.clear();
-            data.assign(reinterpret_cast<char*>(&this->_g_data[this->_g_readPos]), length);
+            data.assign(reinterpret_cast<const char*>(&this->_g_data[this->_g_readPos]), length);
 
             this->_g_readPos += length;
         }
@@ -478,7 +482,7 @@ fge::net::Packet& Packet::operator >>(std::string& data)
     }
     return *this;
 }
-fge::net::Packet& Packet::operator >>(wchar_t* data)
+const fge::net::Packet& Packet::operator >>(wchar_t* data) const
 {
     fge::net::SizeType length = 0;
     this->unpack(&length, sizeof(length));
@@ -506,7 +510,7 @@ fge::net::Packet& Packet::operator >>(wchar_t* data)
     }
     return *this;
 }
-fge::net::Packet& Packet::operator >>(std::wstring& data)
+const fge::net::Packet& Packet::operator >>(std::wstring& data) const
 {
     fge::net::SizeType length = 0;
     this->unpack(&length, sizeof(length));
@@ -534,7 +538,7 @@ fge::net::Packet& Packet::operator >>(std::wstring& data)
     }
     return *this;
 }
-fge::net::Packet& Packet::operator >>(sf::String& data)
+const fge::net::Packet& Packet::operator >>(sf::String& data) const
 {
     fge::net::SizeType length = 0;
     this->unpack(&length, sizeof(length));

--- a/sources/C_packet.cpp
+++ b/sources/C_packet.cpp
@@ -93,26 +93,26 @@ void Packet::reserve(std::size_t reserveSize)
     this->_g_data.reserve(reserveSize);
 }
 
-fge::net::Packet& Packet::append(std::size_t dsize)
+fge::net::Packet& Packet::append(std::size_t size)
 {
-    if (dsize > 0)
+    if (size > 0)
     {
         std::size_t startPos = this->_g_data.size();
-        this->_g_data.resize(startPos + dsize);
+        this->_g_data.resize(startPos + size);
 
         this->_g_lastDataValidity = false;
     }
     return *this;
 }
-fge::net::Packet& Packet::append(const void* data, std::size_t dsize)
+fge::net::Packet& Packet::append(const void* data, std::size_t size)
 {
-    if (data && (dsize > 0))
+    if (data && (size > 0))
     {
         std::size_t startPos = this->_g_data.size();
-        this->_g_data.resize(startPos + dsize);
+        this->_g_data.resize(startPos + size);
 
         //Copy memory
-        for (std::size_t i=0; i<dsize; ++i)
+        for (std::size_t i=0; i<size; ++i)
         {
             this->_g_data[startPos+i] = static_cast<const uint8_t*>(data)[i];
         }
@@ -120,17 +120,17 @@ fge::net::Packet& Packet::append(const void* data, std::size_t dsize)
     }
     return *this;
 }
-fge::net::Packet& Packet::pack(const void* data, std::size_t dsize)
+fge::net::Packet& Packet::pack(const void* data, std::size_t size)
 {
-    if (data && (dsize > 0))
+    if (data && (size > 0))
     {
         std::size_t startPos = this->_g_data.size();
-        this->_g_data.resize(startPos + dsize);
+        this->_g_data.resize(startPos + size);
 
         if constexpr (std::endian::native == std::endian::big)
         {
             //Copy memory
-            for (std::size_t i=0; i<dsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
                 this->_g_data[startPos+i] = static_cast<const uint8_t*>(data)[i];
             }
@@ -138,9 +138,9 @@ fge::net::Packet& Packet::pack(const void* data, std::size_t dsize)
         else
         {
             //Copy memory
-            for (std::size_t i=0; i<dsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
-                this->_g_data[startPos+i] = static_cast<const uint8_t*>(data)[dsize-1-i];
+                this->_g_data[startPos+i] = static_cast<const uint8_t*>(data)[size-1-i];
             }
         }
         this->_g_lastDataValidity = false;
@@ -148,12 +148,12 @@ fge::net::Packet& Packet::pack(const void* data, std::size_t dsize)
     return *this;
 }
 
-bool Packet::write(std::size_t pos, const void* data, std::size_t dsize)
+bool Packet::write(std::size_t pos, const void* data, std::size_t size)
 {
-    if (data && (dsize > 0) && (pos < this->_g_data.size()))
+    if (data && (size > 0) && (pos < this->_g_data.size()))
     {
         //Copy memory
-        for (std::size_t i=0; i<dsize; ++i)
+        for (std::size_t i=0; i<size; ++i)
         {
             this->_g_data[pos+i] = static_cast<const uint8_t*>(data)[i];
         }
@@ -162,14 +162,14 @@ bool Packet::write(std::size_t pos, const void* data, std::size_t dsize)
     }
     return false;
 }
-bool Packet::pack(std::size_t pos, const void* data, std::size_t dsize)
+bool Packet::pack(std::size_t pos, const void* data, std::size_t size)
 {
-    if (data && (dsize > 0) && (pos < this->_g_data.size()))
+    if (data && (size > 0) && (pos < this->_g_data.size()))
     {
         if constexpr (std::endian::native == std::endian::big)
         {
             //Copy memory
-            for (std::size_t i=0; i<dsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
                 this->_g_data[pos+i] = static_cast<const uint8_t*>(data)[i];
             }
@@ -177,9 +177,9 @@ bool Packet::pack(std::size_t pos, const void* data, std::size_t dsize)
         else
         {
             //Copy memory
-            for (std::size_t i=0; i<dsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
-                this->_g_data[pos+i] = static_cast<const uint8_t*>(data)[dsize-1-i];
+                this->_g_data[pos+i] = static_cast<const uint8_t*>(data)[size-1-i];
             }
         }
         this->_g_lastDataValidity = false;
@@ -188,30 +188,30 @@ bool Packet::pack(std::size_t pos, const void* data, std::size_t dsize)
     return false;
 }
 
-fge::net::Packet& Packet::read(void* buff, std::size_t bsize)
+fge::net::Packet& Packet::read(void* buff, std::size_t size)
 {
-    if (buff && (bsize > 0) && (this->_g_readPos+bsize <= this->_g_data.size()))
+    if (buff && (size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
         //Copy to buff
-        for (std::size_t i=0; i<bsize; ++i)
+        for (std::size_t i=0; i<size; ++i)
         {
             static_cast<uint8_t*>(buff)[i] = this->_g_data[this->_g_readPos+i];
         }
-        this->_g_readPos += bsize;
+        this->_g_readPos += size;
         this->_g_valid = true;
         return *this;
     }
     this->_g_valid = false;
     return *this;
 }
-fge::net::Packet& Packet::unpack(void* buff, std::size_t bsize)
+fge::net::Packet& Packet::unpack(void* buff, std::size_t size)
 {
-    if (buff && (bsize > 0) && (this->_g_readPos+bsize <= this->_g_data.size()))
+    if (buff && (size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
         if constexpr (std::endian::native == std::endian::big)
         {
             //Copy to buff
-            for (std::size_t i=0; i<bsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
                 static_cast<uint8_t*>(buff)[i] = this->_g_data[this->_g_readPos+i];
             }
@@ -219,12 +219,12 @@ fge::net::Packet& Packet::unpack(void* buff, std::size_t bsize)
         else
         {
             //Copy to buff
-            for (std::size_t i=0; i<bsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
-                static_cast<uint8_t*>(buff)[bsize-1-i] = this->_g_data[this->_g_readPos+i];
+                static_cast<uint8_t*>(buff)[size-1-i] = this->_g_data[this->_g_readPos+i];
             }
         }
-        this->_g_readPos += bsize;
+        this->_g_readPos += size;
         this->_g_valid = true;
         return *this;
     }
@@ -232,12 +232,12 @@ fge::net::Packet& Packet::unpack(void* buff, std::size_t bsize)
     return *this;
 }
 
-bool Packet::read(std::size_t pos, void* buff, std::size_t bsize) const
+bool Packet::read(std::size_t pos, void* buff, std::size_t size) const
 {
-    if (buff && (bsize > 0) && (pos+bsize <= this->_g_data.size()))
+    if (buff && (size > 0) && (pos+size <= this->_g_data.size()))
     {
         //Copy to buff
-        for (std::size_t i=0; i<bsize; ++i)
+        for (std::size_t i=0; i<size; ++i)
         {
             static_cast<uint8_t*>(buff)[i] = this->_g_data[pos+i];
         }
@@ -245,14 +245,14 @@ bool Packet::read(std::size_t pos, void* buff, std::size_t bsize) const
     }
     return false;
 }
-bool Packet::unpack(std::size_t pos, void* buff, std::size_t bsize) const
+bool Packet::unpack(std::size_t pos, void* buff, std::size_t size) const
 {
-    if (buff && (bsize > 0) && (pos+bsize <= this->_g_data.size()))
+    if (buff && (size > 0) && (pos+size <= this->_g_data.size()))
     {
         if constexpr (std::endian::native == std::endian::big)
         {
             //Copy to buff
-            for (std::size_t i=0; i<bsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
                 static_cast<uint8_t*>(buff)[i] = this->_g_data[pos+i];
             }
@@ -260,9 +260,9 @@ bool Packet::unpack(std::size_t pos, void* buff, std::size_t bsize) const
         else
         {
             //Copy to buff
-            for (std::size_t i=0; i<bsize; ++i)
+            for (std::size_t i=0; i<size; ++i)
             {
-                static_cast<uint8_t*>(buff)[bsize-1-i] = this->_g_data[pos+i];
+                static_cast<uint8_t*>(buff)[size-1-i] = this->_g_data[pos+i];
             }
         }
         return true;
@@ -270,38 +270,38 @@ bool Packet::unpack(std::size_t pos, void* buff, std::size_t bsize) const
     return false;
 }
 
-fge::net::Packet& Packet::shrink(std::size_t dsize)
+fge::net::Packet& Packet::shrink(std::size_t size)
 {
-    if (dsize > 0)
+    if (size > 0)
     {
-        if (dsize >= this->_g_data.size())
+        if (size >= this->_g_data.size())
         {
             this->_g_data.resize(0);
         }
         else
         {
             std::size_t startPos = this->_g_data.size();
-            this->_g_data.resize(startPos - dsize);
+            this->_g_data.resize(startPos - size);
         }
 
         this->_g_lastDataValidity = false;
     }
     return *this;
 }
-bool Packet::erase(std::size_t pos, std::size_t dsize)
+bool Packet::erase(std::size_t pos, std::size_t size)
 {
-    if ((dsize > 0) && (pos+dsize <= this->_g_data.size()))
+    if ((size > 0) && (pos+size <= this->_g_data.size()))
     {
-        this->_g_data.erase(this->_g_data.begin()+pos, this->_g_data.begin()+pos+dsize);
+        this->_g_data.erase(this->_g_data.begin()+pos, this->_g_data.begin()+pos+size);
         this->_g_lastDataValidity = false;
     }
     return false;
 }
-fge::net::Packet& Packet::skip(std::size_t bsize)
+fge::net::Packet& Packet::skip(std::size_t size)
 {
-    if ((bsize > 0) && (this->_g_readPos+bsize <= this->_g_data.size()))
+    if ((size > 0) && (this->_g_readPos+size <= this->_g_data.size()))
     {
-        this->_g_readPos += bsize;
+        this->_g_readPos += size;
         this->_g_valid = true;
         return *this;
     }
@@ -316,6 +316,10 @@ void Packet::setReadPos(std::size_t pos)
 std::size_t Packet::getReadPos() const
 {
     return this->_g_readPos;
+}
+bool Packet::isExtractable(std::size_t size) const
+{
+    return (this->_g_readPos+size) <= this->_g_data.size();
 }
 
 const uint8_t* Packet::getData(std::size_t pos) const
@@ -346,7 +350,7 @@ uint32_t Packet::getLength() const
     return result;
 }
 
-void Packet::setValidity(bool validity)
+void Packet::setValidity(bool validity) const
 {
     this->_g_valid = validity;
 }
@@ -567,9 +571,9 @@ void Packet::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
         buffer[i + offset] = this->_g_data[i];
     }
 }
-void Packet::onReceive(void* data, std::size_t dsize)
+void Packet::onReceive(void* data, std::size_t size)
 {
-    this->append(data, dsize);
+    this->append(data, size);
 }
 
 std::size_t Packet::_defaultReserveSize = FGE_PACKET_DEFAULT_RESERVESIZE;

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -1075,7 +1075,6 @@ void Scene::unpackModification(fge::net::Packet& pck)
             FGE_NET_RULES_START
                 fge::net::rules::RLess<fge::net::SizeType>(objectNetList.size(), pck);
             FGE_NET_RULES_AFFECT_END(buffIndex)
-            pck >> buffIndex;
 
             objectNetList[buffIndex]->applyData(pck);
         }

--- a/sources/C_texture.cpp
+++ b/sources/C_texture.cpp
@@ -117,7 +117,7 @@ Texture::operator const fge::TextureType&() const
     return *this->g_data->_texture;
 }
 
-fge::net::Packet& operator >>(fge::net::Packet& pck, fge::Texture& data)
+const fge::net::Packet& operator >>(const fge::net::Packet& pck, fge::Texture& data)
 {
     std::string textureName;
     pck >> textureName;

--- a/sources/extra_string.cpp
+++ b/sources/extra_string.cpp
@@ -33,10 +33,17 @@
 #include <fmt/compile.h>
 #include <fmt/format.h>
 
+#include <utf8.h>
+
 namespace fge
 {
 namespace string
 {
+
+bool IsValidUtf8String(const std::string& str)
+{
+    return utf8::is_valid(str);
+}
 
 uint8_t ToUint8(const std::string& str)
 {

--- a/sources/main_debug.cpp
+++ b/sources/main_debug.cpp
@@ -196,22 +196,24 @@ public:
     void main()
     {
         fge::net::Packet testPck;
-        testPck << (std::size_t)123;
+        testPck << (std::size_t)123 << (std::size_t)321;
 
         std::size_t b;
         auto aaa = [&](std::size_t v){
             b = v;
         };
 
+        std::size_t c;
+
         FGE_NET_RULES_START
-        fge::net::rules::RMustEqual<std::size_t, false>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}));
-        FGE_NET_RULES_AFFECT_SETTER_END(aaa)
+            fge::net::rules::RMustEqual<std::size_t, false>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}));
+        FGE_NET_RULES_SETTER_END_ELSE(aaa, std::cout << "rule 1 is not valid !" << std::endl; return;)
 
-        /*FGE_NET_RULES_TRY((fge::net::rules::RMustEqual<std::size_t, true>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}) )),
-              std::cout << "VALID" << std::endl;
-        );*/
+        FGE_NET_RULES_START
+            fge::net::rules::RMustEqual<std::size_t, false>(321,fge::net::rules::RRange<std::size_t, false>(100, 400, {&testPck}));
+        FGE_NET_RULES_AFFECT_END_ELSE(c, std::cout << "rule 2 is not valid !" << std::endl; return;)
 
-        std::cout << b << " packet validity : " << std::boolalpha << testPck.isValid() << std::endl;
+        std::cout << c << " " << b << " packet validity : " << std::boolalpha << testPck.isValid() << std::endl;
 
         return;
         fge::_random.setSeed(2);

--- a/sources/main_debug.cpp
+++ b/sources/main_debug.cpp
@@ -195,27 +195,6 @@ public:
 
     void main()
     {
-        fge::net::Packet testPck;
-        testPck << (uint32_t)123 << (uint32_t)321;
-
-        uint32_t b;
-        auto aaa = [&](uint32_t v){
-            b = v;
-        };
-
-        uint32_t c;
-
-        FGE_NET_RULES_START
-            fge::net::rules::RMustEqual<uint32_t, false>(123,fge::net::rules::RRange<uint32_t, false>(0, 200, {&testPck}));
-        FGE_NET_RULES_SETTER_END_ELSE(aaa, std::cout << "rule 1 is not valid !" << std::endl; return;)
-
-        FGE_NET_RULES_START
-            fge::net::rules::RMustEqual<uint32_t, false>(321,fge::net::rules::RRange<uint32_t, false>(100, 400, {&testPck}));
-        FGE_NET_RULES_AFFECT_END_ELSE(c, std::cout << "rule 2 is not valid !" << std::endl; return;)
-
-        std::cout << c << " " << b << " packet validity : " << std::boolalpha << testPck.isValid() << std::endl;
-
-        return;
         fge::_random.setSeed(2);
 
         sf::RenderWindow window(sf::VideoMode(800, 600), "FastEngine "+(std::string)FGE_VERSION_FULL_WITHTAG_STRING);

--- a/sources/main_debug.cpp
+++ b/sources/main_debug.cpp
@@ -195,6 +195,25 @@ public:
 
     void main()
     {
+        fge::net::Packet testPck;
+        testPck << (std::size_t)123;
+
+        std::size_t b;
+        auto aaa = [&](std::size_t v){
+            b = v;
+        };
+
+        FGE_NET_RULES_START
+        fge::net::rules::RMustEqual<std::size_t, false>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}));
+        FGE_NET_RULES_AFFECT_SETTER_END(aaa)
+
+        /*FGE_NET_RULES_TRY((fge::net::rules::RMustEqual<std::size_t, true>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}) )),
+              std::cout << "VALID" << std::endl;
+        );*/
+
+        std::cout << b << " packet validity : " << std::boolalpha << testPck.isValid() << std::endl;
+
+        return;
         fge::_random.setSeed(2);
 
         sf::RenderWindow window(sf::VideoMode(800, 600), "FastEngine "+(std::string)FGE_VERSION_FULL_WITHTAG_STRING);

--- a/sources/main_debug.cpp
+++ b/sources/main_debug.cpp
@@ -196,14 +196,14 @@ public:
     void main()
     {
         fge::net::Packet testPck;
-        testPck << (std::size_t)123 << (std::size_t)321;
+        testPck << (uint32_t)123 << (uint32_t)321;
 
-        std::size_t b;
-        auto aaa = [&](std::size_t v){
+        uint32_t b;
+        auto aaa = [&](uint32_t v){
             b = v;
         };
 
-        std::size_t c;
+        uint32_t c;
 
         FGE_NET_RULES_START
             fge::net::rules::RMustEqual<std::size_t, false>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}));

--- a/sources/main_debug.cpp
+++ b/sources/main_debug.cpp
@@ -206,11 +206,11 @@ public:
         uint32_t c;
 
         FGE_NET_RULES_START
-            fge::net::rules::RMustEqual<std::size_t, false>(123,fge::net::rules::RRange<std::size_t, false>(0, 200, {&testPck}));
+            fge::net::rules::RMustEqual<uint32_t, false>(123,fge::net::rules::RRange<uint32_t, false>(0, 200, {&testPck}));
         FGE_NET_RULES_SETTER_END_ELSE(aaa, std::cout << "rule 1 is not valid !" << std::endl; return;)
 
         FGE_NET_RULES_START
-            fge::net::rules::RMustEqual<std::size_t, false>(321,fge::net::rules::RRange<std::size_t, false>(100, 400, {&testPck}));
+            fge::net::rules::RMustEqual<uint32_t, false>(321,fge::net::rules::RRange<uint32_t, false>(100, 400, {&testPck}));
         FGE_NET_RULES_AFFECT_END_ELSE(c, std::cout << "rule 2 is not valid !" << std::endl; return;)
 
         std::cout << c << " " << b << " packet validity : " << std::boolalpha << testPck.isValid() << std::endl;

--- a/sources/network_manager.cpp
+++ b/sources/network_manager.cpp
@@ -20,9 +20,7 @@
 #include <vector>
 #include <fstream>
 
-namespace fge
-{
-namespace net
+namespace fge::net
 {
 
 uint32_t GetSceneChecksum(fge::Scene& scene)
@@ -64,6 +62,5 @@ bool WriteOnSendPacketDataToFile(fge::net::Packet& pck, const std::string& file)
     return true;
 }
 
-}//end net
-}//end fge
+}//end fge::net
 

--- a/sources/reg_manager.cpp
+++ b/sources/reg_manager.cpp
@@ -71,7 +71,7 @@ fge::Object* Duplicate(const fge::Object* obj)
     {
         return _dataClassIdMap[it->second]->duplicate(obj);
     }
-    return new fge::Object();
+    return nullptr;
 }
 
 bool Replace(std::string_view className, std::unique_ptr<fge::reg::BaseStamp>&& newStamp)
@@ -108,7 +108,7 @@ fge::Object* GetNewClassOf(std::string_view className)
     {
         return _dataClassIdMap[it->second]->createNew();
     }
-    return new fge::Object();
+    return nullptr;
 }
 fge::Object* GetNewClassOf(fge::reg::ClassId classId)
 {
@@ -116,7 +116,7 @@ fge::Object* GetNewClassOf(fge::reg::ClassId classId)
     {
         return _dataClassIdMap[classId]->createNew();
     }
-    return new fge::Object();
+    return nullptr;
 }
 
 fge::reg::ClassId GetClassId(std::string_view className)


### PR DESCRIPTION
In order to avoid bad data extraction from packet, there is a need of a tool/utility to check certain rules before extracting data.
That is what "network rules" is.