### PR TITLE
Context refactor

### DIFF
--- a/examples/clientServerLifeSimulator_004/client/main.cpp
+++ b/examples/clientServerLifeSimulator_004/client/main.cpp
@@ -66,9 +66,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
     fge::shader::LoadFromFile(FGE_OBJSHAPE_INSTANCES_SHADER_VERTEX, "resources/shaders/objShapeInstances_vertex.vert",
@@ -361,7 +361,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
         auto imageIndex = renderWindow.prepareNextFrame(nullptr);
         if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
         {
-            fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+            fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
             renderWindow.beginRenderPass(imageIndex);
 
@@ -373,9 +373,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
         }
     }
 
-    fge::vulkan::GlobalContext->waitIdle();
+    fge::vulkan::GetActiveContext().waitIdle();
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+    fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
 
     mainScene.reset();
 

--- a/examples/deepText_005/main.cpp
+++ b/examples/deepText_005/main.cpp
@@ -153,7 +153,7 @@ public:
             auto imageIndex = renderWindow.prepareNextFrame(nullptr);
             if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
             {
-                fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+                fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
                 renderWindow.beginRenderPass(imageIndex);
 
@@ -167,9 +167,9 @@ public:
             //SDL_Delay(17);
         }
 
-        fge::vulkan::GlobalContext->waitIdle();
+        fge::vulkan::GetActiveContext().waitIdle();
 
-        fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+        fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
     }
 };
 
@@ -192,9 +192,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
     fge::shader::LoadFromFile(FGE_OBJSHAPE_INSTANCES_SHADER_VERTEX, "resources/shaders/objShapeInstances_vertex.vert",

--- a/examples/guiWindow_003/main.cpp
+++ b/examples/guiWindow_003/main.cpp
@@ -157,7 +157,7 @@ public:
             auto imageIndex = renderWindow.prepareNextFrame(nullptr);
             if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
             {
-                fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+                fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
                 renderWindow.beginRenderPass(imageIndex);
 
@@ -169,9 +169,9 @@ public:
             }
         }
 
-        fge::vulkan::GlobalContext->waitIdle();
+        fge::vulkan::GetActiveContext().waitIdle();
 
-        fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+        fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
     }
 };
 
@@ -194,9 +194,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
     fge::shader::LoadFromFile(FGE_OBJSHAPE_INSTANCES_SHADER_VERTEX, "resources/shaders/objShapeInstances_vertex.vert",

--- a/examples/lightAndObstacle_002/main.cpp
+++ b/examples/lightAndObstacle_002/main.cpp
@@ -38,7 +38,11 @@ public:
         OBSTACLE_CONCAVE
     };
 
-    Obstacle() { this->g_vertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP); }
+    Obstacle() :
+            g_vertices(*fge::vulkan::GlobalContext)
+    {
+        this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    }
 
     FGE_OBJ_DEFAULT_COPYMETHOD(Obstacle)
 

--- a/examples/lightAndObstacle_002/main.cpp
+++ b/examples/lightAndObstacle_002/main.cpp
@@ -39,7 +39,7 @@ public:
     };
 
     Obstacle() :
-            g_vertices(*fge::vulkan::GlobalContext)
+            g_vertices(fge::vulkan::GetActiveContext())
     {
         this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
     }
@@ -280,7 +280,7 @@ public:
             auto imageIndex = renderWindow.prepareNextFrame(nullptr);
             if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
             {
-                fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+                fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
                 renderWindow.beginRenderPass(imageIndex);
 
@@ -292,9 +292,9 @@ public:
             }
         }
 
-        fge::vulkan::GlobalContext->waitIdle();
+        fge::vulkan::GetActiveContext().waitIdle();
 
-        fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+        fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
     }
 };
 
@@ -318,9 +318,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
 

--- a/examples/multipleSprites_006/main.cpp
+++ b/examples/multipleSprites_006/main.cpp
@@ -258,7 +258,7 @@ public:
             auto imageIndex = renderWindow.prepareNextFrame(nullptr);
             if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
             {
-                fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+                fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
                 renderWindow.beginRenderPass(imageIndex);
 
@@ -270,9 +270,9 @@ public:
             }
         }
 
-        fge::vulkan::GlobalContext->waitIdle();
+        fge::vulkan::GetActiveContext().waitIdle();
 
-        fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+        fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
     }
 };
 
@@ -299,9 +299,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
     fge::shader::LoadFromFile(FGE_OBJSHAPE_INSTANCES_SHADER_VERTEX, "resources/shaders/objShapeInstances_vertex.vert",

--- a/examples/tileMapAndPathFinding_001/main.cpp
+++ b/examples/tileMapAndPathFinding_001/main.cpp
@@ -294,7 +294,7 @@ public:
             auto imageIndex = renderWindow.prepareNextFrame(nullptr);
             if (imageIndex != FGE_RENDERTARGET_BAD_IMAGE_INDEX)
             {
-                fge::vulkan::GlobalContext->_garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
+                fge::vulkan::GetActiveContext()._garbageCollector.setCurrentFrame(renderWindow.getCurrentFrame());
 
                 renderWindow.beginRenderPass(imageIndex);
 
@@ -306,9 +306,9 @@ public:
             }
         }
 
-        fge::vulkan::GlobalContext->waitIdle();
+        fge::vulkan::GetActiveContext().waitIdle();
 
-        fge::vulkan::GlobalContext->_garbageCollector.enable(false);
+        fge::vulkan::GetActiveContext()._garbageCollector.enable(false);
     }
 };
 
@@ -332,9 +332,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     fge::vulkan::Context::enumerateExtensions();
     vulkanContext.initVulkan(window);
 
-    fge::vulkan::GlobalContext = &vulkanContext;
+    fge::vulkan::SetActiveContext(vulkanContext);
 
-    fge::vulkan::GlobalContext->_garbageCollector.enable(true);
+    vulkanContext._garbageCollector.enable(true);
 
     fge::shader::Init();
     fge::shader::LoadFromFile(FGE_OBJSHAPE_INSTANCES_SHADER_VERTEX, "resources/shaders/objShapeInstances_vertex.vert",

--- a/includes/FastEngine/C_matrix.hpp
+++ b/includes/FastEngine/C_matrix.hpp
@@ -18,6 +18,7 @@
 #define _FGE_C_MATRIX_HPP_INCLUDED
 
 #include "FastEngine/C_vector.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "json.hpp"
 #include <initializer_list>
 

--- a/includes/FastEngine/C_matrix.inl
+++ b/includes/FastEngine/C_matrix.inl
@@ -231,7 +231,7 @@ void Matrix<T>::set(std::initializer_list<std::initializer_list<T>> data)
         {
             if (it->size() != sizex)
             {
-                throw std::runtime_error("Matrix : size must be constant between rows");
+                throw fge::Exception("Matrix : size must be constant between rows");
             }
         }
     }
@@ -320,7 +320,7 @@ void Matrix<T>::setSize(std::size_t sizex, std::size_t sizey)
     }
     if (sizex == 0 || sizey == 0)
     { //Null size, aborting
-        throw std::runtime_error("Matrix : size cannot be 0");
+        throw fge::Exception("Matrix : size cannot be 0");
     }
 
     this->g_mdata.reset(new T[sizex * sizey]);
@@ -466,11 +466,11 @@ void from_json(const nlohmann::json& j, fge::Matrix<T>& r)
 
     if (!datay.is_array())
     {
-        throw std::runtime_error("Matrix json : must be an array");
+        throw fge::Exception("Matrix json : must be an array");
     }
     if (datay.size() != sizey)
     {
-        throw std::runtime_error("Matrix json : size y is not the same");
+        throw fge::Exception("Matrix json : size y is not the same");
     }
 
     r.setSize(sizex, sizey);
@@ -480,11 +480,11 @@ void from_json(const nlohmann::json& j, fge::Matrix<T>& r)
     {
         if (!(*ity).is_array())
         {
-            throw std::runtime_error("Matrix json : must be an array");
+            throw fge::Exception("Matrix json : must be an array");
         }
         if ((*ity).size() != sizex)
         {
-            throw std::runtime_error("Matrix json : size x is not the same");
+            throw fge::Exception("Matrix json : size x is not the same");
         }
 
         std::size_t x = 0;

--- a/includes/FastEngine/C_packet.hpp
+++ b/includes/FastEngine/C_packet.hpp
@@ -31,7 +31,6 @@
 #include <cstdint>
 #include <forward_list>
 #include <list>
-#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/includes/FastEngine/C_propertyList.hpp
+++ b/includes/FastEngine/C_propertyList.hpp
@@ -18,7 +18,7 @@
 #define _FGE_C_PROPERTYLIST_HPP_INCLUDED
 
 #include "FastEngine/C_property.hpp"
-#include <stdexcept>
+#include "FastEngine/fge_except.hpp"
 #include <string>
 #include <unordered_map>
 

--- a/includes/FastEngine/C_propertyList.inl
+++ b/includes/FastEngine/C_propertyList.inl
@@ -67,7 +67,7 @@ const fge::Property& PropertyList::getProperty(const std::string& key) const
     {
         return it->second;
     }
-    throw std::logic_error("key not found !");
+    throw fge::Exception("key not found !");
 }
 
 fge::Property& PropertyList::operator[](const std::string& key)
@@ -81,7 +81,7 @@ const fge::Property& PropertyList::operator[](const std::string& key) const
     {
         return it->second;
     }
-    throw std::logic_error("key not found !");
+    throw fge::Exception("key not found !");
 }
 
 std::size_t PropertyList::getPropertiesSize() const

--- a/includes/FastEngine/fge_except.hpp
+++ b/includes/FastEngine/fge_except.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Guillaume Guillet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FGE_EXCEPT_HPP_INCLUDED_
+#define _FGE_EXCEPT_HPP_INCLUDED_
+
+#include <exception>
+#include <string>
+#include <string_view>
+
+namespace fge
+{
+
+class Exception : public std::exception
+{
+public:
+    explicit Exception(std::string_view sv) :
+            g_what(sv)
+    {}
+    ~Exception() override = default;
+
+    [[nodiscard]] const char* what() const noexcept override { return this->g_what.c_str(); }
+
+private:
+    std::string g_what;
+};
+
+} // namespace fge
+
+#endif // _FGE_EXCEPT_HPP_INCLUDED_

--- a/includes/FastEngine/graphic/C_renderTarget.hpp
+++ b/includes/FastEngine/graphic/C_renderTarget.hpp
@@ -119,9 +119,6 @@ public:
     virtual void endRenderPass() = 0;
     virtual void display(uint32_t imageIndex) = 0;
 
-    virtual void pushExtraCommandBuffer(VkCommandBuffer commandBuffer) const;
-    virtual void pushExtraCommandBuffer(const std::vector<VkCommandBuffer>& commandBuffers) const;
-
     virtual Vector2u getSize() const = 0;
 
     virtual bool isSrgb() const;

--- a/includes/FastEngine/graphic/C_renderTarget.hpp
+++ b/includes/FastEngine/graphic/C_renderTarget.hpp
@@ -31,6 +31,7 @@
 #include "FastEngine/graphic/C_renderStates.hpp"
 #include "FastEngine/graphic/C_view.hpp"
 #include "FastEngine/vulkan/C_blendMode.hpp"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "FastEngine/vulkan/C_descriptorSet.hpp"
 #include "FastEngine/vulkan/C_graphicPipeline.hpp"
 #include "FastEngine/vulkan/C_vertex.hpp"
@@ -52,7 +53,7 @@ namespace fge
 class Texture;
 class Drawable;
 
-class FGE_API RenderTarget
+class FGE_API RenderTarget : public fge::vulkan::ContextAware
 {
 protected:
     explicit RenderTarget(const fge::vulkan::Context& context);
@@ -87,13 +88,13 @@ public:
             std::map<std::string,
                      std::unordered_map<GraphicPipelineKey, fge::vulkan::GraphicPipeline, GraphicPipelineKey>,
                      std::less<>>;
-    using GraphicPipelineConstructor = void (*)(const fge::vulkan::Context*,
-                                                const GraphicPipelineKey&,
+    using GraphicPipelineConstructor = void (*)(fge::vulkan::Context const&,
+                                                GraphicPipelineKey const&,
                                                 fge::vulkan::GraphicPipeline*);
 
     RenderTarget(const RenderTarget& r);
     RenderTarget(RenderTarget&& r) noexcept;
-    virtual ~RenderTarget() = default;
+    ~RenderTarget() override = default;
 
     RenderTarget& operator=(const RenderTarget& r);
     RenderTarget& operator=(RenderTarget&& r) noexcept;
@@ -123,8 +124,6 @@ public:
 
     virtual Vector2u getSize() const = 0;
 
-    [[nodiscard]] const fge::vulkan::Context* getContext() const;
-
     virtual bool isSrgb() const;
 
     [[nodiscard]] virtual VkExtent2D getExtent2D() const = 0;
@@ -142,8 +141,6 @@ private:
 
 protected:
     VkClearColorValue _g_clearColor;
-
-    const fge::vulkan::Context* _g_context;
 
     bool _g_forceGraphicPipelineUpdate;
 

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -80,16 +80,12 @@ private:
 
     void createFramebuffer();
 
-    void createCommandBuffer();
-    void createCommandPool();
-
     fge::vulkan::TextureImage g_textureImage;
 
     VkRenderPass g_renderPass;
 
     VkFramebuffer g_framebuffer;
 
-    VkCommandPool g_commandPool;
     std::vector<VkCommandBuffer> g_commandBuffers;
 
     mutable uint32_t g_currentFrame;

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -40,7 +40,7 @@ class FGE_API RenderTexture : public RenderTarget
 {
 public:
     explicit RenderTexture(const glm::vec<2, int>& size = {1, 1},
-                           const fge::vulkan::Context& context = *fge::vulkan::GlobalContext);
+                           const fge::vulkan::Context& context = fge::vulkan::GetActiveContext());
     RenderTexture(const RenderTexture& r);
     RenderTexture(RenderTexture&& r) noexcept;
     ~RenderTexture() override;

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -36,13 +36,6 @@
 namespace fge
 {
 
-namespace vulkan
-{
-
-class Context;
-
-} // namespace vulkan
-
 class FGE_API RenderTexture : public RenderTarget
 {
 public:

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -49,7 +49,7 @@ public:
     RenderTexture& operator=(RenderTexture&& r) noexcept;
 
     void resize(const glm::vec<2, int>& size);
-    void destroy();
+    void destroy() final;
 
     uint32_t prepareNextFrame(const VkCommandBufferInheritanceInfo* inheritanceInfo) override;
     void beginRenderPass(uint32_t imageIndex) override;

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -64,14 +64,9 @@ public:
     [[nodiscard]] VkCommandBuffer getCommandBuffer() const override;
     [[nodiscard]] VkRenderPass getRenderPass() const override;
 
-    [[nodiscard]] std::vector<VkCommandBuffer> getCommandBuffers() const;
     [[nodiscard]] const fge::vulkan::TextureImage& getTextureImage() const;
 
-    void setCurrentFrame(uint32_t frame) const;
     [[nodiscard]] uint32_t getCurrentFrame() const;
-
-    void pushExtraCommandBuffer(VkCommandBuffer commandBuffer) const override;
-    void pushExtraCommandBuffer(const std::vector<VkCommandBuffer>& commandBuffers) const override;
 
 private:
     void init(const glm::vec<2, int>& size);
@@ -88,9 +83,7 @@ private:
 
     std::vector<VkCommandBuffer> g_commandBuffers;
 
-    mutable uint32_t g_currentFrame;
-
-    mutable std::vector<VkCommandBuffer> g_extraCommandBuffers;
+    uint32_t g_currentFrame;
 
     bool g_isCreated;
 };

--- a/includes/FastEngine/graphic/C_renderWindow.hpp
+++ b/includes/FastEngine/graphic/C_renderWindow.hpp
@@ -49,7 +49,7 @@ public:
     explicit RenderWindow(const fge::vulkan::Context& context);
     ~RenderWindow() override;
 
-    void destroy();
+    void destroy() final;
 
     [[nodiscard]] uint32_t prepareNextFrame(const VkCommandBufferInheritanceInfo* inheritanceInfo) override;
     void beginRenderPass(uint32_t imageIndex) override;

--- a/includes/FastEngine/graphic/C_renderWindow.hpp
+++ b/includes/FastEngine/graphic/C_renderWindow.hpp
@@ -85,9 +85,6 @@ private:
 
     void createFramebuffers();
 
-    void createCommandBuffers();
-    void createCommandPool();
-
     void createSyncObjects();
 
     fge::vulkan::SwapChain g_swapChain;
@@ -96,7 +93,6 @@ private:
 
     std::vector<VkFramebuffer> g_swapChainFramebuffers;
 
-    VkCommandPool g_commandPool = VK_NULL_HANDLE;
     std::vector<VkCommandBuffer> g_commandBuffers;
 
     mutable std::vector<VkCommandBuffer> g_extraCommandBuffers;

--- a/includes/FastEngine/graphic/C_renderWindow.hpp
+++ b/includes/FastEngine/graphic/C_renderWindow.hpp
@@ -60,9 +60,6 @@ public:
 
     bool isSrgb() const override;
 
-    void pushExtraCommandBuffer(VkCommandBuffer commandBuffer) const override;
-    void pushExtraCommandBuffer(const std::vector<VkCommandBuffer>& commandBuffers) const override;
-
     void setPresentMode(VkPresentModeKHR presentMode);
     [[nodiscard]] VkPresentModeKHR getPresentMode() const;
 
@@ -94,9 +91,6 @@ private:
     std::vector<VkFramebuffer> g_swapChainFramebuffers;
 
     std::vector<VkCommandBuffer> g_commandBuffers;
-
-    mutable std::vector<VkCommandBuffer> g_extraCommandBuffers;
-    mutable std::vector<VkFence> g_extraFences;
 
     std::vector<VkSemaphore> g_imageAvailableSemaphores;
     std::vector<VkSemaphore> g_renderFinishedSemaphores;

--- a/includes/FastEngine/graphic/C_surface.hpp
+++ b/includes/FastEngine/graphic/C_surface.hpp
@@ -29,6 +29,15 @@
 namespace fge
 {
 
+#ifdef FGE_DEF_SERVER
+namespace vulkan
+{
+
+class Context;
+
+} // namespace vulkan
+#endif
+
 /**
  * \class Surface
  * \ingroup graphics
@@ -46,6 +55,15 @@ class FGE_API Surface
 {
 public:
     Surface();
+#ifdef FGE_DEF_SERVER
+    //TODO: this is here in order to be interchangeable easily with TextureImage
+    //when building for the server or client target.
+    //For future, I want to remove that and have a TextureImage server version
+    //instead of switching between Surface <-> TextureImage with the fge::TextureType alias
+    explicit Surface([[maybe_unused]] fge::vulkan::Context const& r) :
+            Surface()
+    {}
+#endif
     Surface(int width, int height, fge::Color const& color = {0, 0, 0, 255});
     Surface(Surface const& r);
     Surface(Surface&& r) noexcept;

--- a/includes/FastEngine/graphic/C_transform.hpp
+++ b/includes/FastEngine/graphic/C_transform.hpp
@@ -39,7 +39,7 @@ struct TransformUboData
 class FGE_API Transform
 {
 public:
-    explicit Transform(const fge::vulkan::Context& context = *fge::vulkan::GlobalContext);
+    explicit Transform(const fge::vulkan::Context& context = fge::vulkan::GetActiveContext());
     Transform(const Transform& r);
     Transform(Transform&& r) noexcept = default;
     ~Transform();

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -88,6 +88,10 @@ public:
      * The INDIRECT_OUTSIDE_RENDER_SCOPE_EXECUTION type is used to execute your commands inside
      * a reusable command buffer that is submitted to the graphics queue at the same time as a render command buffer
      * in a RenderScreen. This is ideal for performance like copying staging buffers to device local buffers.
+     * 
+     * This is also synced with a semaphore that is signaled when the command buffer have finished executing so this
+     * assure that every commands are finished before rendering.
+     *
      * All this commands must be executed outside a render scope.
      *
      * \warning This function must be pared with endSingleTimeCommands()

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -124,6 +124,32 @@ public:
     [[nodiscard]] const PhysicalDevice& getPhysicalDevice() const;
 
     /**
+     * \brief Retrieve a command pool for graphics commands
+     *
+     * This command pool is used to create command buffers that will be used to submit commands to the graphics queue.
+     *
+     * This command pool is created with the following flags:
+     * VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
+     *
+     * \return The command pool
+     */
+    [[nodiscard]] VkCommandPool getGraphicsCommandPool() const;
+    /**
+     * \brief Allocate graphics command buffers
+     *
+     * This is a shortcut for vkAllocateCommandBuffers with the graphics command pool.
+     *
+     * \see getGraphicsCommandPool()
+     *
+     * \param level The level of the command buffers (primary or secondary)
+     * \param commandBuffers An array of VkCommandBuffer structures in which the resulting command buffer objects are returned
+     * \param commandBufferCount The number of command buffers to allocate
+     */
+    void allocateGraphicsCommandBuffers(VkCommandBufferLevel level,
+                                        VkCommandBuffer commandBuffers[],
+                                        uint32_t commandBufferCount) const;
+
+    /**
      * \brief Copy a buffer to another
      *
      * Fill a command buffer with a copy command in order to copy a buffer to another.
@@ -289,7 +315,7 @@ private:
 
     mutable VmaAllocator g_allocator;
 
-    VkCommandPool g_commandPool;
+    VkCommandPool g_graphicsCommandPool;
     bool g_isCreated;
 };
 

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -110,8 +110,8 @@ private:
     mutable std::map<std::string, fge::vulkan::DescriptorSetLayout, std::less<>> g_cacheLayouts;
     DescriptorPool g_multiUseDescriptorPool;
 
-    fge::vulkan::DescriptorSetLayout g_textureLayout{*this};
-    fge::vulkan::DescriptorSetLayout g_transformLayout{*this};
+    fge::vulkan::DescriptorSetLayout g_textureLayout;
+    fge::vulkan::DescriptorSetLayout g_transformLayout;
     DescriptorPool g_textureDescriptorPool;
     DescriptorPool g_transformDescriptorPool;
 

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -110,8 +110,8 @@ private:
     mutable std::map<std::string, fge::vulkan::DescriptorSetLayout, std::less<>> g_cacheLayouts;
     DescriptorPool g_multiUseDescriptorPool;
 
-    fge::vulkan::DescriptorSetLayout g_textureLayout;
-    fge::vulkan::DescriptorSetLayout g_transformLayout;
+    fge::vulkan::DescriptorSetLayout g_textureLayout{*this};
+    fge::vulkan::DescriptorSetLayout g_transformLayout{*this};
     DescriptorPool g_textureDescriptorPool;
     DescriptorPool g_transformDescriptorPool;
 

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -292,6 +292,31 @@ public:
      */
     [[nodiscard]] VmaAllocator getAllocator() const;
 
+    /**
+     * \brief Push a graphics command buffer to a list
+     *
+     * This is used to keep track of executable command buffers that will be submitted to the graphics queue.
+     * This list must be cleared once the command buffers are submitted. Generally, this is done by a RenderScreen
+     * when the RenderScreen::display() method is called.
+     *
+     * \param commandBuffer The command buffer to push
+     */
+    void pushGraphicsCommandBuffer(VkCommandBuffer commandBuffer) const;
+    /**
+     * \brief Retrieve the list of executable graphics command buffers
+     *
+     * \see pushGraphicsCommandBuffer()
+     *
+     * \return The list of executable graphics command buffers
+     */
+    [[nodiscard]] std::vector<VkCommandBuffer> const& getGraphicsCommandBuffers() const;
+    /**
+     * \brief Clear the list of executable graphics command buffers
+     *
+     * \see pushGraphicsCommandBuffer()
+     */
+    void clearGraphicsCommandBuffers() const;
+
     fge::vulkan::GarbageCollector _garbageCollector;
 
 private:
@@ -315,6 +340,7 @@ private:
 
     mutable VmaAllocator g_allocator;
 
+    mutable std::vector<VkCommandBuffer> g_executableGraphicsCommandBuffers;
     VkCommandPool g_graphicsCommandPool;
     bool g_isCreated;
 };

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -40,27 +40,82 @@
 namespace fge::vulkan
 {
 
+/**
+ * \class Context
+ * \brief Vulkan context
+ * \ingroup vulkan
+ *
+ * This class is the main starting point for Vulkan usage.
+ */
 class FGE_API Context
 {
 public:
     Context();
-    Context(const Context& r) = delete;
+    Context(Context const& r) = delete;
     Context(Context&& r) noexcept = delete;
     ~Context();
 
-    Context& operator=(const Context& r) = delete;
+    Context& operator=(Context const& r) = delete;
     Context& operator=(Context&& r) noexcept = delete;
 
     void destroy();
 
+    /**
+     * \brief Begin a single time command
+     *
+     * This return a command buffer that is ready to be used.
+     *
+     * \warning This function must be pared with endSingleTimeCommands()
+     *
+     * \return The command buffer
+     */
     [[nodiscard]] VkCommandBuffer beginSingleTimeCommands() const;
+    /**
+     * \brief End a single time command
+     *
+     * The command is queued to the graphics queue and is destroyed.
+     *
+     * \todo vkQueueWaitIdle is called but should be removed
+     *
+     * \param commandBuffer The command buffer to end
+     */
     void endSingleTimeCommands(VkCommandBuffer commandBuffer) const;
 
+    /**
+     * \brief Initialize Volk (Vulkan loader)
+     *
+     * \warning This function must be called once before any other graphics usage, generally at the start of the program
+     */
     static void initVolk();
 
+    /**
+     * \brief Initialize Vulkan
+     *
+     * Once a SDL window is correctly created, this function must be called to initialize Vulkan.
+     *
+     * \param window The SDL window
+     */
     void initVulkan(SDL_Window* window);
-    static void enumerateExtensions();
 
+    /**
+     * \brief Enumerate to standard output the available extensions
+     *
+     * \see retrieveExtensions()
+     */
+    static void enumerateExtensions();
+    /**
+     * \brief Retrieve the available extensions
+     *
+     * \return The available extensions
+     */
+    [[nodiscard]] static std::vector<std::string> retrieveExtensions();
+
+    /**
+     * \brief Wait for the device to be idle
+     *
+     * This is generally called before any new commands submission.
+     * Also when the program is about to exit, this function must be called to make sure that all commands are finished.
+     */
     void waitIdle();
 
     [[nodiscard]] const Instance& getInstance() const;
@@ -68,15 +123,68 @@ public:
     [[nodiscard]] const LogicalDevice& getLogicalDevice() const;
     [[nodiscard]] const PhysicalDevice& getPhysicalDevice() const;
 
+    /**
+     * \brief Copy a buffer to another
+     *
+     * Fill a command buffer with a copy command in order to copy a buffer to another.
+     *
+     * \param srcBuffer The source buffer
+     * \param dstBuffer The destination buffer
+     * \param size The size of the buffer to copy
+     */
     void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size) const;
+    /**
+     * \brief Transition an image layout
+     *
+     * Fill a command buffer with a transition command in order to transition an image layout.
+     *
+     * \param image The image
+     * \param format The format of the image
+     * \param oldLayout The old layout
+     * \param newLayout The new layout
+     */
     void transitionImageLayout(VkImage image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout) const;
+    /**
+     * \brief Copy a buffer to an image
+     *
+     * Fill a command buffer with a copy command in order to copy a buffer to an image.
+     *
+     * \param buffer The buffer
+     * \param image The image
+     * \param width Width of the image
+     * \param height Height of the image
+     * \param offsetX An offset on the X axis
+     * \param offsetY An offset on the Y axis
+     */
     void copyBufferToImage(VkBuffer buffer,
                            VkImage image,
                            uint32_t width,
                            uint32_t height,
                            int32_t offsetX = 0,
                            int32_t offsetY = 0) const;
+    /**
+     * \brief Copy an image to a buffer
+     *
+     * Fill a command buffer with a copy command in order to copy an image to a buffer.
+     *
+     * \param image The image
+     * \param buffer The buffer
+     * \param width The width of the image
+     * \param height The height of the image
+     */
     void copyImageToBuffer(VkImage image, VkBuffer buffer, uint32_t width, uint32_t height) const;
+    /**
+     * \brief Copy an image to another image
+     *
+     * Fill a command buffer with a copy command in order to copy an image to another image.
+     *
+     * \param srcImage The source image
+     * \param dstImage The destination image
+     * \param width The width of the image
+     * \param height The height of the image
+     * \param offsetX An offset on the X axis
+     * \param offsetY An offset on the Y axis
+     */
     void copyImageToImage(VkImage srcImage,
                           VkImage dstImage,
                           uint32_t width,
@@ -84,14 +192,78 @@ public:
                           int32_t offsetX = 0,
                           int32_t offsetY = 0) const;
 
+    /**
+     * \brief Retrieve or create a descriptor set layout from a key
+     *
+     * Certain objects need a custom descriptor set layout to be created for custom shaders.
+     *
+     * If the descriptor set layout is not already created, it will be created and cached and
+     * you will be able to fill it with the necessary bindings.
+     *
+     * \param key The key to retrieve the descriptor set layout
+     * \return The descriptor set layout
+     */
     [[nodiscard]] fge::vulkan::DescriptorSetLayout& getCacheLayout(std::string_view key) const;
+    /**
+     * \brief Retrieve a "multi-usage" descriptor pool
+     *
+     * This pool was created with the following types:
+     * VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+     * VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+     * VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC
+     *
+     * \return The descriptor pool
+     */
     [[nodiscard]] const DescriptorPool& getMultiUseDescriptorPool() const;
 
+    /**
+     * \brief Retrieve a "texture" descriptor set layout
+     *
+     * This layout is used with default provided shaders.
+     *
+     * This layout was created with the following:
+     * binding: FGE_VULKAN_TEXTURE_BINDING
+     * type: VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+     * stage: VK_SHADER_STAGE_FRAGMENT_BIT
+     *
+     * \return The descriptor set layout
+     */
     [[nodiscard]] const fge::vulkan::DescriptorSetLayout& getTextureLayout() const;
+    /**
+     * \brief Retrieve a "transform" descriptor set layout
+     *
+     * This layout is used with default provided shaders.
+     *
+     * This layout was created with the following:
+     * binding: FGE_VULKAN_TRANSFORM_BINDING
+     * type: VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+     * stage: VK_SHADER_STAGE_VERTEX_BIT
+     *
+     * \return The descriptor set layout
+     */
     [[nodiscard]] const fge::vulkan::DescriptorSetLayout& getTransformLayout() const;
+    /**
+     * \brief Retrieve a "texture" descriptor pool
+     *
+     * This pool can only contain VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER type.
+     *
+     * \return The descriptor pool
+     */
     [[nodiscard]] const DescriptorPool& getTextureDescriptorPool() const;
+    /**
+     * \brief Retrieve a "transform" descriptor pool
+     *
+     * This pool can only contain VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER type.
+     *
+     * \return The descriptor pool
+     */
     [[nodiscard]] const DescriptorPool& getTransformDescriptorPool() const;
 
+    /**
+     * \brief Retrieve the VMA (Vulkan Memory Allocator)
+     *
+     * \return The allocator
+     */
     [[nodiscard]] VmaAllocator getAllocator() const;
 
     fge::vulkan::GarbageCollector _garbageCollector;

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -17,6 +17,8 @@
 #ifndef _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
 #define _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
 
+#include <stdexcept>
+
 namespace fge::vulkan
 {
 
@@ -26,19 +28,35 @@ class ContextAware
 {
 public:
     explicit constexpr ContextAware(Context const& context) :
-            _g_context{&context}
+            g_context{&context}
     {}
-    constexpr ContextAware(ContextAware const& r) = default;
-    constexpr ContextAware(ContextAware&& r) noexcept = default;
+    ContextAware(ContextAware const& r) = default;
+    ContextAware(ContextAware&& r) noexcept = default;
     constexpr ~ContextAware() = default;
 
-    [[nodiscard]] constexpr Context const* getContext() const { return this->_g_context; }
+    ContextAware& operator=(ContextAware const& r) = delete;
+    ContextAware& operator=(ContextAware&& r) noexcept = delete;
+
+    [[nodiscard]] constexpr Context const* getContext() const { return this->g_context; }
+    inline void swapContext(Context const& context)
+    {
+        this->destroy();
+        this->g_context = &context;
+    }
+
+    virtual void destroy() = 0;
 
 protected:
-    constexpr ContextAware& operator=(ContextAware const& r) = default;
-    constexpr ContextAware& operator=(ContextAware&& r) = default;
+    inline void verifyContext(ContextAware const& r)
+    {
+        if (this->g_context != r.g_context)
+        {
+            throw std::runtime_error("ContextAware objects assignment with different Context !");
+        }
+    }
 
-    Context const* _g_context{nullptr};
+private:
+    Context const* g_context{nullptr};
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -30,9 +30,9 @@ public:
     explicit constexpr ContextAware(Context const& context) :
             g_context{&context}
     {}
-    ContextAware(ContextAware const& r) = default;
-    ContextAware(ContextAware&& r) noexcept = default;
-    constexpr ~ContextAware() = default;
+    constexpr ContextAware(ContextAware const& r) = default;
+    constexpr ContextAware(ContextAware&& r) noexcept = default;
+    constexpr virtual ~ContextAware() = default;
 
     ContextAware& operator=(ContextAware const& r) = delete;
     ContextAware& operator=(ContextAware&& r) noexcept = delete;

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -32,7 +32,7 @@ public:
     {}
     constexpr ContextAware(ContextAware const& r) = default;
     constexpr ContextAware(ContextAware&& r) noexcept = default;
-    constexpr virtual ~ContextAware() = default;
+    virtual ~ContextAware() = default;
 
     ContextAware& operator=(ContextAware const& r) = delete;
     ContextAware& operator=(ContextAware&& r) noexcept = delete;

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -17,7 +17,7 @@
 #ifndef _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
 #define _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
 
-#include <stdexcept>
+#include "FastEngine/fge_except.hpp"
 
 namespace fge::vulkan
 {
@@ -51,7 +51,7 @@ protected:
     {
         if (this->g_context != r.g_context)
         {
-            throw std::runtime_error("ContextAware objects assignment with different Context !");
+            throw fge::Exception("ContextAware objects assignment with different Context !");
         }
     }
 

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -37,7 +37,7 @@ public:
     ContextAware& operator=(ContextAware const& r) = delete;
     ContextAware& operator=(ContextAware&& r) noexcept = delete;
 
-    [[nodiscard]] constexpr Context const* getContext() const { return this->g_context; }
+    [[nodiscard]] constexpr Context const& getContext() const { return *this->g_context; }
     inline void swapContext(Context const& context)
     {
         this->destroy();

--- a/includes/FastEngine/vulkan/C_contextAware.hpp
+++ b/includes/FastEngine/vulkan/C_contextAware.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Guillaume Guillet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
+#define _FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED
+
+namespace fge::vulkan
+{
+
+class Context;
+
+class ContextAware
+{
+public:
+    explicit constexpr ContextAware(Context const& context) :
+            _g_context{&context}
+    {}
+    constexpr ContextAware(ContextAware const& r) = default;
+    constexpr ContextAware(ContextAware&& r) noexcept = default;
+    constexpr ~ContextAware() = default;
+
+    [[nodiscard]] constexpr Context const* getContext() const { return this->_g_context; }
+
+protected:
+    constexpr ContextAware& operator=(ContextAware const& r) = default;
+    constexpr ContextAware& operator=(ContextAware&& r) = default;
+
+    Context const* _g_context{nullptr};
+};
+
+} // namespace fge::vulkan
+
+#endif //_FGE_VULKAN_C_CONTEXTAWARE_HPP_INCLUDED

--- a/includes/FastEngine/vulkan/C_descriptorPool.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorPool.hpp
@@ -55,7 +55,6 @@ public:
      * When the number of descriptor sets allocated reach the maxSetsPerPool,
      * a new pool is created.
      *
-     * \param context The context
      * \param descriptorPoolSizes A vector of VkDescriptorPoolSize
      * \param maxSetsPerPool The max number of descriptor sets per pool
      * \param isUnique If \b true, only one pool is created and will fail if the maxSetsPerPool is reached

--- a/includes/FastEngine/vulkan/C_descriptorPool.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorPool.hpp
@@ -44,7 +44,7 @@ public:
     explicit DescriptorPool(Context const& context);
     DescriptorPool(const DescriptorPool& r) = delete;
     DescriptorPool(DescriptorPool&& r) noexcept;
-    ~DescriptorPool();
+    ~DescriptorPool() override;
 
     DescriptorPool& operator=(const DescriptorPool& r) = delete;
     DescriptorPool& operator=(DescriptorPool&& r) noexcept = delete;

--- a/includes/FastEngine/vulkan/C_descriptorPool.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorPool.hpp
@@ -19,6 +19,7 @@
 
 #include "FastEngine/fastengine_extern.hpp"
 #include "volk.h"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "SDL_vulkan.h"
 #include <optional>
 #include <vector>
@@ -26,7 +27,6 @@
 namespace fge::vulkan
 {
 
-class Context;
 class DescriptorSet;
 
 /**
@@ -38,10 +38,10 @@ class DescriptorSet;
  * a way to resize it. This class help by allocating any number of descriptor sets
  * by creating multiple pools if needed.
  */
-class FGE_API DescriptorPool
+class FGE_API DescriptorPool : public ContextAware
 {
 public:
-    DescriptorPool();
+    explicit DescriptorPool(Context const& context);
     DescriptorPool(const DescriptorPool& r) = delete;
     DescriptorPool(DescriptorPool&& r) noexcept;
     ~DescriptorPool();
@@ -61,12 +61,11 @@ public:
      * \param isUnique If \b true, only one pool is created and will fail if the maxSetsPerPool is reached
      * \param individuallyFree If \b true, the descriptor sets are individually freed
      */
-    void create(const Context& context,
-                std::vector<VkDescriptorPoolSize>&& descriptorPoolSizes,
+    void create(std::vector<VkDescriptorPoolSize>&& descriptorPoolSizes,
                 uint32_t maxSetsPerPool,
                 bool isUnique,
                 bool individuallyFree);
-    void destroy();
+    void destroy() final;
 
     /**
      * \brief Allocate a descriptor set
@@ -100,7 +99,6 @@ public:
     [[nodiscard]] uint32_t getMaxSetsPerPool() const;
     [[nodiscard]] bool isUnique() const;
     [[nodiscard]] bool isCreated() const;
-    [[nodiscard]] const Context* getContext() const;
 
 private:
     struct Pool
@@ -118,8 +116,6 @@ private:
     bool g_isUnique;
     bool g_isCreated;
     bool g_individuallyFree;
-
-    const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_descriptorSet.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorSet.hpp
@@ -84,7 +84,7 @@ public:
 
     [[nodiscard]] VkDescriptorSet get() const;
     [[nodiscard]] const DescriptorPool* getPool() const;
-    [[nodiscard]] const Context* getContext() const;
+    [[nodiscard]] Context const* getContext() const;
 
     /**
      * \brief Update the descriptor set

--- a/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
@@ -66,7 +66,7 @@ public:
 
     void create(std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
                 VkDescriptorBindingFlagsEXT const* bindingFlags = nullptr);
-    void destroy();
+    void destroy() final;
 
     [[nodiscard]] VkDescriptorSetLayout getLayout() const;
     [[nodiscard]] const std::vector<VkDescriptorSetLayoutBinding>& getBindings() const;

--- a/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
@@ -59,7 +59,7 @@ public:
     explicit DescriptorSetLayout(Context const& context);
     DescriptorSetLayout(const DescriptorSetLayout& r) = delete; ///TODO
     DescriptorSetLayout(DescriptorSetLayout&& r) noexcept;
-    ~DescriptorSetLayout();
+    ~DescriptorSetLayout() override;
 
     DescriptorSetLayout& operator=(const DescriptorSetLayout& r) = delete; ///TODO
     DescriptorSetLayout& operator=(DescriptorSetLayout&& r) noexcept;

--- a/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
+++ b/includes/FastEngine/vulkan/C_descriptorSetLayout.hpp
@@ -19,14 +19,13 @@
 
 #include "FastEngine/fastengine_extern.hpp"
 #include "volk.h"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "SDL_vulkan.h"
 #include <initializer_list>
 #include <vector>
 
 namespace fge::vulkan
 {
-
-class Context;
 
 /**
  * \ingroup vulkan
@@ -54,10 +53,10 @@ CreateSimpleLayoutBinding(uint32_t binding, VkDescriptorType type, VkShaderStage
  * Essentially, this class abstract creation and destruction of the descriptor set layout.
  * It also enable copy and move semantics.
  */
-class FGE_API DescriptorSetLayout
+class FGE_API DescriptorSetLayout : public ContextAware
 {
 public:
-    DescriptorSetLayout();
+    explicit DescriptorSetLayout(Context const& context);
     DescriptorSetLayout(const DescriptorSetLayout& r) = delete; ///TODO
     DescriptorSetLayout(DescriptorSetLayout&& r) noexcept;
     ~DescriptorSetLayout();
@@ -65,21 +64,17 @@ public:
     DescriptorSetLayout& operator=(const DescriptorSetLayout& r) = delete; ///TODO
     DescriptorSetLayout& operator=(DescriptorSetLayout&& r) noexcept;
 
-    void create(const Context& context,
-                std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
+    void create(std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
                 VkDescriptorBindingFlagsEXT const* bindingFlags = nullptr);
     void destroy();
 
     [[nodiscard]] VkDescriptorSetLayout getLayout() const;
     [[nodiscard]] const std::vector<VkDescriptorSetLayoutBinding>& getBindings() const;
     [[nodiscard]] std::size_t getBindingsCount() const;
-    [[nodiscard]] const Context* getContext() const;
 
 private:
     VkDescriptorSetLayout g_descriptorSetLayout;
     std::vector<VkDescriptorSetLayoutBinding> g_bindings;
-
-    const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_garbageCollector.hpp
+++ b/includes/FastEngine/vulkan/C_garbageCollector.hpp
@@ -37,6 +37,7 @@ enum class GarbageType
     GARBAGE_GRAPHIC_PIPELINE,
     GARBAGE_PIPELINE_LAYOUT,
     GARBAGE_COMMAND_POOL,
+    GARBAGE_COMMAND_BUFFER,
     GARBAGE_FRAMEBUFFER,
     GARBAGE_RENDERPASS,
     GARBAGE_SAMPLER,
@@ -111,6 +112,20 @@ struct GarbageCommandPool
 
     GarbageType _type;
     VkCommandPool _commandPool;
+    VkDevice _logicalDevice;
+};
+struct GarbageCommandBuffer
+{
+    constexpr GarbageCommandBuffer(VkCommandPool commandPool, VkCommandBuffer commandBuffer, VkDevice logicalDevice) :
+            _type(GarbageType::GARBAGE_COMMAND_BUFFER),
+            _commandPool(commandPool),
+            _commandBuffer(commandBuffer),
+            _logicalDevice(logicalDevice)
+    {}
+
+    GarbageType _type;
+    VkCommandPool _commandPool;
+    VkCommandBuffer _commandBuffer;
     VkDevice _logicalDevice;
 };
 struct GarbageFramebuffer
@@ -199,6 +214,9 @@ public:
     constexpr Garbage(const GarbageCommandPool& garbage) :
             g_data(garbage)
     {}
+    constexpr Garbage(const GarbageCommandBuffer& garbage) :
+            g_data(garbage)
+    {}
     constexpr Garbage(const GarbageFramebuffer& garbage) :
             g_data(garbage)
     {}
@@ -243,6 +261,9 @@ private:
         explicit constexpr Data(const GarbageCommandPool& data) :
                 _commandPool{data}
         {}
+        explicit constexpr Data(const GarbageCommandBuffer& data) :
+                _commandBuffer{data}
+        {}
         explicit constexpr Data(const GarbageFramebuffer& data) :
                 _framebuffer{data}
         {}
@@ -262,6 +283,7 @@ private:
         GarbageGraphicPipeline _graphicPipeline;
         GarbagePipelineLayout _pipelineLayout;
         GarbageCommandPool _commandPool;
+        GarbageCommandBuffer _commandBuffer;
         GarbageFramebuffer _framebuffer;
         GarbageRenderPass _renderPass;
         GarbageSampler _sampler;

--- a/includes/FastEngine/vulkan/C_graphicPipeline.hpp
+++ b/includes/FastEngine/vulkan/C_graphicPipeline.hpp
@@ -20,6 +20,7 @@
 #include "FastEngine/fastengine_extern.hpp"
 #include "volk.h"
 #include "C_blendMode.hpp"
+#include "C_contextAware.hpp"
 #include "C_shader.hpp"
 #include "C_vertex.hpp"
 #include "C_vertexBuffer.hpp"
@@ -33,15 +34,15 @@ namespace fge::vulkan
 class SwapChain;
 class LogicalDevice;
 
-class FGE_API GraphicPipeline
+class FGE_API GraphicPipeline : public ContextAware
 {
 public:
-    explicit GraphicPipeline(const Context& context);
-    GraphicPipeline(const GraphicPipeline& r);
+    explicit GraphicPipeline(Context const& context);
+    GraphicPipeline(GraphicPipeline const& r);
     GraphicPipeline(GraphicPipeline&& r) noexcept;
     ~GraphicPipeline();
 
-    GraphicPipeline& operator=(const GraphicPipeline& r) = delete;
+    GraphicPipeline& operator=(GraphicPipeline const& r) = delete;
     GraphicPipeline& operator=(GraphicPipeline&& r) noexcept = delete;
 
     bool updateIfNeeded(VkRenderPass renderPass, bool force = false) const;
@@ -95,9 +96,8 @@ public:
 
     [[nodiscard]] VkPipelineLayout getPipelineLayout() const;
     [[nodiscard]] VkPipeline getPipeline() const;
-    [[nodiscard]] const Context* getContext();
 
-    void destroy();
+    void destroy() final;
 
 private:
     void updatePipelineLayout() const;
@@ -122,8 +122,6 @@ private:
 
     std::vector<VkPushConstantRange> g_pushConstantRanges;
     std::vector<VkDescriptorSetLayout> g_descriptorSetLayouts;
-
-    mutable const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_graphicPipeline.hpp
+++ b/includes/FastEngine/vulkan/C_graphicPipeline.hpp
@@ -31,16 +31,13 @@
 namespace fge::vulkan
 {
 
-class SwapChain;
-class LogicalDevice;
-
 class FGE_API GraphicPipeline : public ContextAware
 {
 public:
     explicit GraphicPipeline(Context const& context);
     GraphicPipeline(GraphicPipeline const& r);
     GraphicPipeline(GraphicPipeline&& r) noexcept;
-    ~GraphicPipeline();
+    ~GraphicPipeline() override;
 
     GraphicPipeline& operator=(GraphicPipeline const& r) = delete;
     GraphicPipeline& operator=(GraphicPipeline&& r) noexcept = delete;

--- a/includes/FastEngine/vulkan/C_textureImage.hpp
+++ b/includes/FastEngine/vulkan/C_textureImage.hpp
@@ -20,6 +20,7 @@
 #include "FastEngine/fastengine_extern.hpp"
 #include "FastEngine/C_rect.hpp"
 #include "FastEngine/C_vector.hpp"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "FastEngine/vulkan/C_descriptorSet.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include "SDL_vulkan.h"
@@ -28,23 +29,20 @@
 namespace fge::vulkan
 {
 
-class Context;
-class PhysicalDevice;
-
-class FGE_API TextureImage
+class FGE_API TextureImage : public ContextAware
 {
 public:
-    TextureImage();
+    explicit TextureImage(Context const& context);
     TextureImage(const TextureImage& r) = delete;
     TextureImage(TextureImage&& r) noexcept;
-    ~TextureImage();
+    ~TextureImage() override;
 
     TextureImage& operator=(const TextureImage& r) = delete;
     TextureImage& operator=(TextureImage&& r) noexcept;
 
-    bool create(const Context& context, const glm::vec<2, int>& size);
-    bool create(const Context& context, SDL_Surface* surface);
-    void destroy();
+    bool create(const glm::vec<2, int>& size);
+    bool create(SDL_Surface* surface);
+    void destroy() final;
 
     [[nodiscard]] SDL_Surface* copyToSurface() const;
 
@@ -68,8 +66,6 @@ public:
     void setFilter(VkFilter filter);
     [[nodiscard]] VkFilter getFilter() const;
 
-    [[nodiscard]] const Context* getContext() const;
-
     [[nodiscard]] const fge::vulkan::DescriptorSet& getDescriptorSet() const;
 
     [[nodiscard]] fge::Vector2f normalizeTextureCoords(const fge::Vector2i& coords) const;
@@ -78,7 +74,7 @@ public:
     [[nodiscard]] uint32_t getModificationCount() const;
 
 private:
-    void createTextureSampler(const PhysicalDevice& physicalDevice);
+    void createTextureSampler();
 
     VkImage g_textureImage;
     VmaAllocation g_textureImageAllocation;
@@ -95,8 +91,6 @@ private:
     fge::vulkan::DescriptorSet g_textureDescriptorSet;
 
     uint32_t g_modificationCount;
-
-    const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_uniformBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_uniformBuffer.hpp
@@ -18,6 +18,7 @@
 #define _FGE_VULKAN_C_UNIFORMBUFFER_HPP_INCLUDED
 
 #include "FastEngine/fastengine_extern.hpp"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include "SDL_vulkan.h"
 #include <cstdint>
@@ -28,28 +29,24 @@
 namespace fge::vulkan
 {
 
-class Context;
-
-class FGE_API UniformBuffer
+class FGE_API UniformBuffer : public ContextAware
 {
 public:
-    UniformBuffer();
+    explicit UniformBuffer(Context const& context);
     UniformBuffer(const UniformBuffer& r);
     UniformBuffer(UniformBuffer&& r) noexcept;
-    ~UniformBuffer();
+    ~UniformBuffer() override;
 
     UniformBuffer& operator=(const UniformBuffer& r) = delete;     ///TODO
     UniformBuffer& operator=(UniformBuffer&& r) noexcept = delete; ///TODO
 
-    void create(const Context& context, VkDeviceSize bufferSize, bool isStorageBuffer = false);
-    void destroy();
+    void create(VkDeviceSize bufferSize, bool isStorageBuffer = false);
+    void destroy() final;
 
     [[nodiscard]] VkBuffer getBuffer() const;
     [[nodiscard]] VmaAllocation getBufferAllocation() const;
     [[nodiscard]] void* getBufferMapped() const;
     [[nodiscard]] VkDeviceSize getBufferSize() const;
-
-    [[nodiscard]] const Context* getContext() const;
 
     void copyData(const void* data, std::size_t size) const;
 
@@ -62,8 +59,6 @@ private:
 #else
     mutable std::vector<uint8_t> g_uniformBuffer;
 #endif
-
-    const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/C_vertexBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_vertexBuffer.hpp
@@ -20,6 +20,7 @@
 #include "FastEngine/fastengine_extern.hpp"
 #include "C_vertex.hpp"
 #include "FastEngine/C_rect.hpp"
+#include "FastEngine/vulkan/C_contextAware.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include "SDL_vulkan.h"
 #include <limits>
@@ -30,10 +31,6 @@
 namespace fge::vulkan
 {
 
-class LogicalDevice;
-class PhysicalDevice;
-class Context;
-
 enum class BufferTypes
 {
     UNINITIALIZED,
@@ -43,27 +40,24 @@ enum class BufferTypes
     DEFAULT = LOCAL
 };
 
-class FGE_API VertexBuffer
+class FGE_API VertexBuffer : public ContextAware
 {
 public:
-    VertexBuffer();
+    explicit VertexBuffer(Context const& context);
     VertexBuffer(const VertexBuffer& r);
     VertexBuffer(VertexBuffer&& r) noexcept;
-    ~VertexBuffer();
+    ~VertexBuffer() override;
 
     VertexBuffer& operator=(const VertexBuffer& r);
     VertexBuffer& operator=(VertexBuffer&& r) noexcept;
 
-    void create(const Context& context,
-                std::size_t vertexSize,
-                VkPrimitiveTopology topology,
-                BufferTypes type = BufferTypes::DEFAULT);
+    void create(std::size_t vertexSize, VkPrimitiveTopology topology, BufferTypes type = BufferTypes::DEFAULT);
 
     void clear();
     void resize(std::size_t vertexSize);
     void append(const Vertex& vertex);
 
-    void destroy();
+    void destroy() final;
 
     void bind(VkCommandBuffer commandBuffer) const;
 
@@ -80,7 +74,6 @@ public:
 
     [[nodiscard]] VkBuffer getVerticesBuffer() const;
     [[nodiscard]] VmaAllocation getVerticesBufferAllocation() const;
-    [[nodiscard]] const Context* getContext() const;
 
     [[nodiscard]] BufferTypes getType() const;
 
@@ -104,28 +97,26 @@ private:
     BufferTypes g_type;
 
     mutable VkPrimitiveTopology g_primitiveTopology;
-
-    const Context* g_context;
 };
 
-class FGE_API IndexBuffer
+class FGE_API IndexBuffer : public ContextAware
 {
 public:
-    IndexBuffer();
+    explicit IndexBuffer(Context const& context);
     IndexBuffer(const IndexBuffer& r);
     IndexBuffer(IndexBuffer&& r) noexcept;
-    ~IndexBuffer();
+    ~IndexBuffer() override;
 
     IndexBuffer& operator=(const IndexBuffer& r);
     IndexBuffer& operator=(IndexBuffer&& r) noexcept;
 
-    void create(const Context& context, std::size_t indexSize, BufferTypes type = BufferTypes::DEFAULT);
+    void create(std::size_t indexSize, BufferTypes type = BufferTypes::DEFAULT);
 
     void clear();
     void resize(std::size_t indexSize);
     void append(uint16_t index = std::numeric_limits<uint16_t>::max());
 
-    void destroy();
+    void destroy() final;
 
     void bind(VkCommandBuffer commandBuffer) const;
 
@@ -139,7 +130,6 @@ public:
 
     [[nodiscard]] VkBuffer getIndicesBuffer() const;
     [[nodiscard]] VmaAllocation getIndicesBufferAllocation() const;
-    [[nodiscard]] const Context* getContext() const;
 
     [[nodiscard]] BufferTypes getType() const;
 
@@ -159,8 +149,6 @@ private:
     mutable bool g_needUpdate;
 
     BufferTypes g_type;
-
-    const Context* g_context;
 };
 
 } // namespace fge::vulkan

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -40,7 +40,8 @@ class Context;
 FGE_API extern std::vector<const char*> ValidationLayers;
 FGE_API extern std::vector<const char*> DeviceExtensions;
 
-FGE_API extern Context* GlobalContext;
+FGE_API extern Context& GetActiveContext();
+FGE_API extern void SetActiveContext(Context& context);
 
 FGE_API bool CheckValidationLayerSupport(const char* layerName);
 

--- a/sources/C_clientList.cpp
+++ b/sources/C_clientList.cpp
@@ -70,7 +70,7 @@ ClientList::remove(fge::net::ClientList::ClientListData::const_iterator itPos,
 {
     if (!lock.owns_lock() || lock.mutex() != &this->g_mutex)
     {
-        throw std::runtime_error("ClientList::remove : lock is not owned or not my mutex !");
+        throw fge::Exception("ClientList::remove : lock is not owned or not my mutex !");
     }
     if (this->g_enableClientEventsFlag)
     {
@@ -99,7 +99,7 @@ fge::net::ClientList::ClientListData::iterator ClientList::begin(const std::uniq
 {
     if (!lock.owns_lock() || lock.mutex() != &this->g_mutex)
     {
-        throw std::runtime_error("ClientList::begin : lock is not owned or not my mutex !");
+        throw fge::Exception("ClientList::begin : lock is not owned or not my mutex !");
     }
     return this->g_data.begin();
 }
@@ -108,7 +108,7 @@ ClientList::begin(const std::unique_lock<std::recursive_mutex>& lock) const
 {
     if (!lock.owns_lock() || lock.mutex() != &this->g_mutex)
     {
-        throw std::runtime_error("ClientList::begin : lock is not owned or not my mutex !");
+        throw fge::Exception("ClientList::begin : lock is not owned or not my mutex !");
     }
     return this->g_data.cbegin();
 }
@@ -116,7 +116,7 @@ fge::net::ClientList::ClientListData::iterator ClientList::end(const std::unique
 {
     if (!lock.owns_lock() || lock.mutex() != &this->g_mutex)
     {
-        throw std::runtime_error("ClientList::begin : lock is not owned or not my mutex !");
+        throw fge::Exception("ClientList::begin : lock is not owned or not my mutex !");
     }
     return this->g_data.end();
 }
@@ -125,7 +125,7 @@ ClientList::end(const std::unique_lock<std::recursive_mutex>& lock) const
 {
     if (!lock.owns_lock() || lock.mutex() != &this->g_mutex)
     {
-        throw std::runtime_error("ClientList::begin : lock is not owned or not my mutex !");
+        throw fge::Exception("ClientList::begin : lock is not owned or not my mutex !");
     }
     return this->g_data.cend();
 }

--- a/sources/C_event.cpp
+++ b/sources/C_event.cpp
@@ -30,7 +30,7 @@ Event::Event(SDL_Window* window)
     SDL_GetWindowPosition(window, &this->g_windowPosition.x, &this->g_windowPosition.y);
 }
 Event::Event(const fge::RenderWindow& renderWindow) :
-        Event(renderWindow.getContext()->getInstance().getWindow())
+        Event(renderWindow.getContext().getInstance().getWindow())
 {}
 #endif //FGE_DEF_SERVER
 

--- a/sources/C_packetBZ2.cpp
+++ b/sources/C_packetBZ2.cpp
@@ -16,8 +16,8 @@
 
 #include "FastEngine/C_packetBZ2.hpp"
 #include "FastEngine/fge_endian.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "bzlib.h"
-#include <stdexcept>
 
 namespace fge
 {
@@ -54,16 +54,16 @@ void PacketBZ2::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
     switch (result)
     {
     case BZ_CONFIG_ERROR:
-        throw std::invalid_argument("Config error !");
+        throw fge::Exception("Config error !");
         break;
     case BZ_PARAM_ERROR:
-        throw std::invalid_argument("Parameter error !");
+        throw fge::Exception("Parameter error !");
         break;
     case BZ_MEM_ERROR:
-        throw std::out_of_range("No enough memory !");
+        throw fge::Exception("No enough memory !");
         break;
     case BZ_OUTBUFF_FULL:
-        throw std::out_of_range("Data > Buffer");
+        throw fge::Exception("Data > Buffer");
         break;
     }
 
@@ -78,7 +78,7 @@ void PacketBZ2::onReceive(void* data, std::size_t dsize)
 {
     if (dsize < 4)
     {
-        throw std::invalid_argument("Received a bad packet !");
+        throw fge::Exception("Received a bad packet !");
     }
 
     uint32_t dataUncompressedSize = 0;
@@ -88,7 +88,7 @@ void PacketBZ2::onReceive(void* data, std::size_t dsize)
 
     if (dataUncompressedSize > fge::net::PacketBZ2::_maxUncompressedReceivedSize)
     {
-        throw std::range_error("received packet is too big !");
+        throw fge::Exception("received packet is too big !");
     }
 
     dataUncompressedSize += 10;
@@ -101,16 +101,16 @@ void PacketBZ2::onReceive(void* data, std::size_t dsize)
     switch (result)
     {
     case BZ_CONFIG_ERROR:
-        throw std::invalid_argument("PacketBZ2 : Config error !");
+        throw fge::Exception("PacketBZ2 : Config error !");
         break;
     case BZ_PARAM_ERROR:
-        throw std::invalid_argument("PacketBZ2 : Parameter error !");
+        throw fge::Exception("PacketBZ2 : Parameter error !");
         break;
     case BZ_MEM_ERROR:
-        throw std::out_of_range("PacketBZ2 : No enough memory !");
+        throw fge::Exception("PacketBZ2 : No enough memory !");
         break;
     case BZ_OUTBUFF_FULL:
-        throw std::out_of_range("PacketBZ2 : Data > Buffer");
+        throw fge::Exception("PacketBZ2 : Data > Buffer");
         break;
     }
 

--- a/sources/C_packetLZ4.cpp
+++ b/sources/C_packetLZ4.cpp
@@ -16,9 +16,9 @@
 
 #include "FastEngine/C_packetLZ4.hpp"
 #include "FastEngine/fge_endian.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "lz4.h"
 #include "lz4hc.h"
-#include <stdexcept>
 
 namespace fge
 {
@@ -52,7 +52,7 @@ void PacketLZ4::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
 
     if (dataDstSize <= 0)
     { //input size is incorrect (too large or negative)
-        throw std::invalid_argument("input size is too large or negative !");
+        throw fge::Exception("input size is too large or negative !");
     }
 
     buffer.resize(dataDstSize + sizeof(uint32_t) + offset);
@@ -61,7 +61,7 @@ void PacketLZ4::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
             dataSrc, reinterpret_cast<char*>(buffer.data()) + sizeof(uint32_t) + offset, dataSrcSize, dataDstSize);
     if (dataCompressedSize <= 0)
     {
-        throw std::overflow_error("no enough buffer size or compression error !");
+        throw fge::Exception("no enough buffer size or compression error !");
     }
 
     *reinterpret_cast<uint32_t*>(buffer.data() + offset) = fge::SwapHostNetEndian_32(dataSrcSize);
@@ -75,7 +75,7 @@ void PacketLZ4::onReceive(void* data, std::size_t dsize)
 {
     if (dsize < 4)
     {
-        throw std::invalid_argument("received a bad packet !");
+        throw fge::Exception("received a bad packet !");
     }
 
     uint32_t dataUncompressedSize = 0;
@@ -86,7 +86,7 @@ void PacketLZ4::onReceive(void* data, std::size_t dsize)
     if ((dataUncompressedSize > LZ4_MAX_INPUT_SIZE) ||
         (dataUncompressedSize > fge::net::PacketLZ4::_maxUncompressedReceivedSize))
     {
-        throw std::range_error("received packet is too big !");
+        throw fge::Exception("received packet is too big !");
     }
 
     this->g_buffer.resize(dataUncompressedSize + 10);
@@ -96,7 +96,7 @@ void PacketLZ4::onReceive(void* data, std::size_t dsize)
 
     if (dataUncompressedFinalSize <= 0)
     {
-        throw std::invalid_argument("received a bad packet !");
+        throw fge::Exception("received a bad packet !");
     }
 
     this->append(this->g_buffer.data(), dataUncompressedFinalSize);
@@ -131,7 +131,7 @@ void PacketLZ4HC::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
 
     if (dataDstSize <= 0)
     { //input size is incorrect (too large or negative)
-        throw std::invalid_argument("input size is too large or negative !");
+        throw fge::Exception("input size is too large or negative !");
     }
 
     buffer.resize(dataDstSize + sizeof(uint32_t) + offset);
@@ -141,7 +141,7 @@ void PacketLZ4HC::onSend(std::vector<uint8_t>& buffer, std::size_t offset)
                             dataDstSize, this->g_compressionLevel);
     if (dataCompressedSize <= 0)
     {
-        throw std::overflow_error("no enough buffer size or compression error !");
+        throw fge::Exception("no enough buffer size or compression error !");
     }
 
     *reinterpret_cast<uint32_t*>(buffer.data() + offset) = fge::SwapHostNetEndian_32(dataSrcSize);
@@ -155,7 +155,7 @@ void PacketLZ4HC::onReceive(void* data, std::size_t dsize)
 {
     if (dsize < 4)
     {
-        throw std::invalid_argument("received a bad packet !");
+        throw fge::Exception("received a bad packet !");
     }
 
     uint32_t dataUncompressedSize = 0;
@@ -166,7 +166,7 @@ void PacketLZ4HC::onReceive(void* data, std::size_t dsize)
     if ((dataUncompressedSize > LZ4_MAX_INPUT_SIZE) ||
         (dataUncompressedSize > fge::net::PacketLZ4HC::_maxUncompressedReceivedSize))
     {
-        throw std::range_error("received packet is too big !");
+        throw fge::Exception("received packet is too big !");
     }
 
     this->g_buffer.resize(dataUncompressedSize + 10);
@@ -176,7 +176,7 @@ void PacketLZ4HC::onReceive(void* data, std::size_t dsize)
 
     if (dataUncompressedFinalSize <= 0)
     {
-        throw std::invalid_argument("received a bad packet !");
+        throw fge::Exception("received a bad packet !");
     }
 
     this->append(this->g_buffer.data(), dataUncompressedFinalSize);

--- a/sources/C_tilelayer.cpp
+++ b/sources/C_tilelayer.cpp
@@ -20,7 +20,7 @@ namespace fge
 {
 
 TileLayer::Tile::Tile() :
-        g_vertexBuffer(*fge::vulkan::GlobalContext)
+        g_vertexBuffer(fge::vulkan::GetActiveContext())
 {
     this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::DEVICE);
 }

--- a/sources/C_tilelayer.cpp
+++ b/sources/C_tilelayer.cpp
@@ -19,10 +19,10 @@
 namespace fge
 {
 
-TileLayer::Tile::Tile()
+TileLayer::Tile::Tile() :
+        g_vertexBuffer(*fge::vulkan::GlobalContext)
 {
-    this->g_vertexBuffer.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-                                fge::vulkan::BufferTypes::DEVICE);
+    this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::DEVICE);
 }
 
 void TileLayer::Tile::setGid(TileId gid)

--- a/sources/graphic/C_ftFont.cpp
+++ b/sources/graphic/C_ftFont.cpp
@@ -595,7 +595,7 @@ bool FreeTypeFont::setCurrentSize(fge::CharacterSize characterSize) const
 }
 
 FreeTypeFont::Page::Page(bool smooth) :
-        _texture(*fge::vulkan::GlobalContext),
+        _texture(fge::vulkan::GetActiveContext()),
         _nextRow(3)
 {
     // Make sure that the texture is initialized by default

--- a/sources/graphic/C_ftFont.cpp
+++ b/sources/graphic/C_ftFont.cpp
@@ -549,8 +549,8 @@ fge::RectInt FreeTypeFont::findGlyphRect(Page& page, unsigned int width, unsigne
             if ((textureWidth * 2 <= maxImageDimension) && (textureHeight * 2 <= maxImageDimension))
             {
                 // Make the texture 2 times bigger
-                fge::vulkan::TextureImage newTexture;
-                newTexture.create(*page._texture.getContext(), {textureWidth * 2, textureHeight * 2});
+                fge::vulkan::TextureImage newTexture{*page._texture.getContext()};
+                newTexture.create({textureWidth * 2, textureHeight * 2});
                 newTexture.setFilter(g_isSmooth ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
                 newTexture.update(page._texture, {0, 0});
                 page._texture = std::move(newTexture);
@@ -595,6 +595,7 @@ bool FreeTypeFont::setCurrentSize(fge::CharacterSize characterSize) const
 }
 
 FreeTypeFont::Page::Page(bool smooth) :
+        _texture(*fge::vulkan::GlobalContext),
         _nextRow(3)
 {
     // Make sure that the texture is initialized by default
@@ -611,7 +612,7 @@ FreeTypeFont::Page::Page(bool smooth) :
     }
 
     // Create the texture
-    this->_texture.create(*fge::vulkan::GlobalContext, surface.get());
+    this->_texture.create(surface.get());
     this->_texture.setFilter(smooth ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
 }
 

--- a/sources/graphic/C_ftFont.cpp
+++ b/sources/graphic/C_ftFont.cpp
@@ -544,12 +544,12 @@ fge::RectInt FreeTypeFont::findGlyphRect(Page& page, unsigned int width, unsigne
             const unsigned int textureWidth = page._texture.getSize().x;
             const unsigned int textureHeight = page._texture.getSize().y;
 
-            auto maxImageDimension = page._texture.getContext()->getPhysicalDevice().getMaxImageDimension2D();
+            auto maxImageDimension = page._texture.getContext().getPhysicalDevice().getMaxImageDimension2D();
 
             if ((textureWidth * 2 <= maxImageDimension) && (textureHeight * 2 <= maxImageDimension))
             {
                 // Make the texture 2 times bigger
-                fge::vulkan::TextureImage newTexture{*page._texture.getContext()};
+                fge::vulkan::TextureImage newTexture{page._texture.getContext()};
                 newTexture.create({textureWidth * 2, textureHeight * 2});
                 newTexture.setFilter(g_isSmooth ? VK_FILTER_LINEAR : VK_FILTER_NEAREST);
                 newTexture.update(page._texture, {0, 0});

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -361,9 +361,6 @@ void RenderTarget::draw(const fge::RenderStates& states, const fge::vulkan::Grap
     }
 }
 
-void RenderTarget::pushExtraCommandBuffer([[maybe_unused]] VkCommandBuffer commandBuffer) const {}
-void RenderTarget::pushExtraCommandBuffer([[maybe_unused]] const std::vector<VkCommandBuffer>& commandBuffers) const {}
-
 bool RenderTarget::isSrgb() const
 { //TODO: maybe delete that
     return false;

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -28,8 +28,8 @@ namespace fge
 namespace
 {
 
-void DefaultGraphicPipelineWithTexture_constructor(const fge::vulkan::Context* context,
-                                                   const fge::RenderTarget::GraphicPipelineKey& key,
+void DefaultGraphicPipelineWithTexture_constructor(fge::vulkan::Context const& context,
+                                                   fge::RenderTarget::GraphicPipelineKey const& key,
                                                    fge::vulkan::GraphicPipeline* graphicPipeline)
 {
     graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_FRAGMENT)->_shader);
@@ -38,10 +38,10 @@ void DefaultGraphicPipelineWithTexture_constructor(const fge::vulkan::Context* c
     graphicPipeline->setPrimitiveTopology(key._topology);
 
     graphicPipeline->setDescriptorSetLayouts(
-            {context->getTransformLayout().getLayout(), context->getTextureLayout().getLayout()});
+            {context.getTransformLayout().getLayout(), context.getTextureLayout().getLayout()});
 }
-void DefaultGraphicPipeline_constructor(const fge::vulkan::Context* context,
-                                        const fge::RenderTarget::GraphicPipelineKey& key,
+void DefaultGraphicPipeline_constructor(fge::vulkan::Context const& context,
+                                        fge::RenderTarget::GraphicPipelineKey const& key,
                                         fge::vulkan::GraphicPipeline* graphicPipeline)
 {
     graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_NOTEXTURE_FRAGMENT)->_shader);
@@ -49,7 +49,7 @@ void DefaultGraphicPipeline_constructor(const fge::vulkan::Context* context,
     graphicPipeline->setBlendMode(key._blendMode);
     graphicPipeline->setPrimitiveTopology(key._topology);
 
-    graphicPipeline->setDescriptorSetLayouts({context->getTransformLayout().getLayout()});
+    graphicPipeline->setDescriptorSetLayouts({context.getTransformLayout().getLayout()});
 }
 
 } // end namespace
@@ -57,8 +57,8 @@ void DefaultGraphicPipeline_constructor(const fge::vulkan::Context* context,
 const fge::vulkan::TextureImage* RenderTarget::gLastTexture = nullptr;
 
 RenderTarget::RenderTarget(const fge::vulkan::Context& context) :
+        fge::vulkan::ContextAware(context),
         _g_clearColor(fge::Color::White),
-        _g_context(&context),
         _g_forceGraphicPipelineUpdate(false)
 {}
 
@@ -70,36 +70,36 @@ void RenderTarget::initialize()
 }
 
 RenderTarget::RenderTarget(const RenderTarget& r) :
+        fge::vulkan::ContextAware(r),
         g_defaultView(r.g_defaultView),
         g_view(r.g_view),
         _g_clearColor(r._g_clearColor),
-        _g_context(r._g_context),
         _g_forceGraphicPipelineUpdate(r._g_forceGraphicPipelineUpdate)
 {}
 RenderTarget::RenderTarget(RenderTarget&& r) noexcept :
+        fge::vulkan::ContextAware(static_cast<fge::vulkan::ContextAware&&>(r)),
         g_defaultView(r.g_defaultView),
         g_view(r.g_view),
         _g_clearColor(r._g_clearColor),
-        _g_context(r._g_context),
         _g_forceGraphicPipelineUpdate(r._g_forceGraphicPipelineUpdate),
         _g_graphicPipelineCache(std::move(r._g_graphicPipelineCache))
 {}
 
 RenderTarget& RenderTarget::operator=(const RenderTarget& r)
 {
+    this->verifyContext(r);
     this->g_defaultView = r.g_defaultView;
     this->g_view = r.g_view;
     this->_g_clearColor = r._g_clearColor;
-    this->_g_context = r._g_context;
     this->_g_forceGraphicPipelineUpdate = r._g_forceGraphicPipelineUpdate;
     return *this;
 }
 RenderTarget& RenderTarget::operator=(RenderTarget&& r) noexcept
 {
+    this->verifyContext(r);
     this->g_defaultView = r.g_defaultView;
     this->g_view = r.g_view;
     this->_g_clearColor = r._g_clearColor;
-    this->_g_context = r._g_context;
     this->_g_forceGraphicPipelineUpdate = r._g_forceGraphicPipelineUpdate;
     this->_g_graphicPipelineCache = std::move(r._g_graphicPipelineCache);
     return *this;
@@ -364,13 +364,8 @@ void RenderTarget::draw(const fge::RenderStates& states, const fge::vulkan::Grap
 void RenderTarget::pushExtraCommandBuffer([[maybe_unused]] VkCommandBuffer commandBuffer) const {}
 void RenderTarget::pushExtraCommandBuffer([[maybe_unused]] const std::vector<VkCommandBuffer>& commandBuffers) const {}
 
-const fge::vulkan::Context* RenderTarget::getContext() const
-{
-    return this->_g_context;
-}
-
 bool RenderTarget::isSrgb() const
-{
+{ //TODO: maybe delete that
     return false;
 }
 
@@ -393,11 +388,11 @@ fge::vulkan::GraphicPipeline* RenderTarget::getGraphicPipeline(std::string_view 
     }
     else
     {
-        graphicPipeline = &itName->second.emplace(key, fge::vulkan::GraphicPipeline{*this->_g_context}).first->second;
+        graphicPipeline = &itName->second.emplace(key, fge::vulkan::GraphicPipeline{this->getContext()}).first->second;
 
         if (constructor != nullptr)
         {
-            constructor(this->_g_context, key, graphicPipeline);
+            constructor(this->getContext(), key, graphicPipeline);
         }
     }
 

--- a/sources/graphic/C_renderTexture.cpp
+++ b/sources/graphic/C_renderTexture.cpp
@@ -37,7 +37,7 @@ RenderTexture::RenderTexture(const glm::vec<2, int>& size, const fge::vulkan::Co
 }
 RenderTexture::RenderTexture(const RenderTexture& r) :
         RenderTarget(r),
-        g_textureImage(*r.getContext()),
+        g_textureImage(r.getContext()),
         g_renderPass(VK_NULL_HANDLE),
         g_framebuffer(VK_NULL_HANDLE),
         g_commandPool(VK_NULL_HANDLE),
@@ -108,11 +108,11 @@ void RenderTexture::destroy()
     {
         this->clearGraphicPipelineCache();
 
-        VkDevice logicalDevice = this->_g_context->getLogicalDevice().getDevice();
+        VkDevice logicalDevice = this->getContext().getLogicalDevice().getDevice();
 
-        this->_g_context->_garbageCollector.push(fge::vulkan::GarbageCommandPool(this->g_commandPool, logicalDevice));
-        this->_g_context->_garbageCollector.push(fge::vulkan::GarbageFramebuffer(this->g_framebuffer, logicalDevice));
-        this->_g_context->_garbageCollector.push(fge::vulkan::GarbageRenderPass(this->g_renderPass, logicalDevice));
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageCommandPool(this->g_commandPool, logicalDevice));
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageFramebuffer(this->g_framebuffer, logicalDevice));
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageRenderPass(this->g_renderPass, logicalDevice));
 
         this->g_textureImage.destroy();
 
@@ -291,7 +291,7 @@ void RenderTexture::createRenderPass()
     renderPassInfo.dependencyCount = dependencies.size();
     renderPassInfo.pDependencies = dependencies.data();
 
-    if (vkCreateRenderPass(this->_g_context->getLogicalDevice().getDevice(), &renderPassInfo, nullptr,
+    if (vkCreateRenderPass(this->getContext().getLogicalDevice().getDevice(), &renderPassInfo, nullptr,
                            &this->g_renderPass) != VK_SUCCESS)
     {
         throw fge::Exception("failed to create render pass!");
@@ -311,7 +311,7 @@ void RenderTexture::createFramebuffer()
     framebufferInfo.height = this->g_textureImage.getSize().y;
     framebufferInfo.layers = 1;
 
-    if (vkCreateFramebuffer(this->_g_context->getLogicalDevice().getDevice(), &framebufferInfo, nullptr,
+    if (vkCreateFramebuffer(this->getContext().getLogicalDevice().getDevice(), &framebufferInfo, nullptr,
                             &this->g_framebuffer) != VK_SUCCESS)
     {
         throw fge::Exception("failed to create framebuffer!");
@@ -328,7 +328,7 @@ void RenderTexture::createCommandBuffer()
     allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     allocInfo.commandBufferCount = FGE_MAX_FRAMES_IN_FLIGHT;
 
-    if (vkAllocateCommandBuffers(this->_g_context->getLogicalDevice().getDevice(), &allocInfo,
+    if (vkAllocateCommandBuffers(this->getContext().getLogicalDevice().getDevice(), &allocInfo,
                                  this->g_commandBuffers.data()) != VK_SUCCESS)
     {
         throw fge::Exception("failed to allocate command buffers!");
@@ -337,14 +337,14 @@ void RenderTexture::createCommandBuffer()
 void RenderTexture::createCommandPool()
 {
     auto queueFamilyIndices =
-            this->_g_context->getPhysicalDevice().findQueueFamilies(this->_g_context->getSurface().getSurface());
+            this->getContext().getPhysicalDevice().findQueueFamilies(this->getContext().getSurface().getSurface());
 
     VkCommandPoolCreateInfo poolInfo{};
     poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
     poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     poolInfo.queueFamilyIndex = queueFamilyIndices._graphicsFamily.value();
 
-    if (vkCreateCommandPool(this->_g_context->getLogicalDevice().getDevice(), &poolInfo, nullptr,
+    if (vkCreateCommandPool(this->getContext().getLogicalDevice().getDevice(), &poolInfo, nullptr,
                             &this->g_commandPool) != VK_SUCCESS)
     {
         throw fge::Exception("failed to create command pool!");

--- a/sources/graphic/C_renderTexture.cpp
+++ b/sources/graphic/C_renderTexture.cpp
@@ -18,7 +18,6 @@
 #include "FastEngine/graphic/C_transform.hpp"
 #include "FastEngine/graphic/C_transformable.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
-#include "SDL_events.h"
 #include "glm/gtc/type_ptr.hpp"
 
 namespace fge
@@ -26,6 +25,7 @@ namespace fge
 
 RenderTexture::RenderTexture(const glm::vec<2, int>& size, const fge::vulkan::Context& context) :
         RenderTarget(context),
+        g_textureImage(context),
         g_renderPass(VK_NULL_HANDLE),
         g_framebuffer(VK_NULL_HANDLE),
         g_commandPool(VK_NULL_HANDLE),
@@ -37,6 +37,7 @@ RenderTexture::RenderTexture(const glm::vec<2, int>& size, const fge::vulkan::Co
 }
 RenderTexture::RenderTexture(const RenderTexture& r) :
         RenderTarget(r),
+        g_textureImage(*r.getContext()),
         g_renderPass(VK_NULL_HANDLE),
         g_framebuffer(VK_NULL_HANDLE),
         g_commandPool(VK_NULL_HANDLE),
@@ -47,7 +48,7 @@ RenderTexture::RenderTexture(const RenderTexture& r) :
     this->initialize();
 }
 RenderTexture::RenderTexture(RenderTexture&& r) noexcept :
-        RenderTarget(std::move(r)),
+        RenderTarget(static_cast<RenderTarget&&>(r)),
         g_textureImage(std::move(r.g_textureImage)),
         g_renderPass(r.g_renderPass),
         g_framebuffer(r.g_framebuffer),
@@ -227,7 +228,7 @@ void RenderTexture::init(const glm::vec<2, int>& size)
     }
     this->g_isCreated = true;
 
-    this->g_textureImage.create(*this->_g_context, size);
+    this->g_textureImage.create(size);
 
     this->createRenderPass();
 

--- a/sources/graphic/C_renderTexture.cpp
+++ b/sources/graphic/C_renderTexture.cpp
@@ -136,7 +136,7 @@ uint32_t RenderTexture::prepareNextFrame(const VkCommandBufferInheritanceInfo* i
 
     if (vkBeginCommandBuffer(this->g_commandBuffers[this->g_currentFrame], &beginInfo) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to begin recording command buffer!");
+        throw fge::Exception("failed to begin recording command buffer!");
     }
 
     return FGE_RENDERTARGET_BAD_IMAGE_INDEX;
@@ -165,7 +165,7 @@ void RenderTexture::display([[maybe_unused]] uint32_t imageIndex)
 {
     if (vkEndCommandBuffer(this->g_commandBuffers[this->g_currentFrame]) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to record command buffer!");
+        throw fge::Exception("failed to record command buffer!");
     }
 }
 
@@ -294,7 +294,7 @@ void RenderTexture::createRenderPass()
     if (vkCreateRenderPass(this->_g_context->getLogicalDevice().getDevice(), &renderPassInfo, nullptr,
                            &this->g_renderPass) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create render pass!");
+        throw fge::Exception("failed to create render pass!");
     }
 }
 
@@ -314,7 +314,7 @@ void RenderTexture::createFramebuffer()
     if (vkCreateFramebuffer(this->_g_context->getLogicalDevice().getDevice(), &framebufferInfo, nullptr,
                             &this->g_framebuffer) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create framebuffer!");
+        throw fge::Exception("failed to create framebuffer!");
     }
 }
 
@@ -331,7 +331,7 @@ void RenderTexture::createCommandBuffer()
     if (vkAllocateCommandBuffers(this->_g_context->getLogicalDevice().getDevice(), &allocInfo,
                                  this->g_commandBuffers.data()) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to allocate command buffers!");
+        throw fge::Exception("failed to allocate command buffers!");
     }
 }
 void RenderTexture::createCommandPool()
@@ -347,7 +347,7 @@ void RenderTexture::createCommandPool()
     if (vkCreateCommandPool(this->_g_context->getLogicalDevice().getDevice(), &poolInfo, nullptr,
                             &this->g_commandPool) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create command pool!");
+        throw fge::Exception("failed to create command pool!");
     }
 }
 

--- a/sources/graphic/C_renderWindow.cpp
+++ b/sources/graphic/C_renderWindow.cpp
@@ -100,7 +100,7 @@ uint32_t RenderWindow::prepareNextFrame([[maybe_unused]] const VkCommandBufferIn
     }
     else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
     {
-        throw std::runtime_error("failed to acquire swap chain image!");
+        throw fge::Exception("failed to acquire swap chain image!");
     }
 
     // Only reset the fence if we are submitting work
@@ -115,7 +115,7 @@ uint32_t RenderWindow::prepareNextFrame([[maybe_unused]] const VkCommandBufferIn
 
     if (vkBeginCommandBuffer(this->g_commandBuffers[this->g_currentFrame], &beginInfo) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to begin recording command buffer!");
+        throw fge::Exception("failed to begin recording command buffer!");
     }
 
     return imageIndex;
@@ -151,7 +151,7 @@ void RenderWindow::display(uint32_t imageIndex)
 {
     if (vkEndCommandBuffer(this->g_commandBuffers[this->g_currentFrame]) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to record command buffer!");
+        throw fge::Exception("failed to record command buffer!");
     }
 
     VkSubmitInfo submitInfo{};
@@ -175,7 +175,7 @@ void RenderWindow::display(uint32_t imageIndex)
     if (vkQueueSubmit(this->_g_context->getLogicalDevice().getGraphicQueue(), 1, &submitInfo,
                       this->g_inFlightFences[this->g_currentFrame]) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to submit draw command buffer!");
+        throw fge::Exception("failed to submit draw command buffer!");
     }
 
     this->g_extraCommandBuffers.clear();
@@ -202,7 +202,7 @@ void RenderWindow::display(uint32_t imageIndex)
     }
     else if (result != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to present swap chain image!");
+        throw fge::Exception("failed to present swap chain image!");
     }
 
     this->g_currentFrame = (this->g_currentFrame + 1) % FGE_MAX_FRAMES_IN_FLIGHT;
@@ -374,7 +374,7 @@ void RenderWindow::createRenderPass()
     if (vkCreateRenderPass(this->_g_context->getLogicalDevice().getDevice(), &renderPassInfo, nullptr,
                            &this->g_renderPass) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create render pass!");
+        throw fge::Exception("failed to create render pass!");
     }
 }
 
@@ -398,7 +398,7 @@ void RenderWindow::createFramebuffers()
         if (vkCreateFramebuffer(this->_g_context->getLogicalDevice().getDevice(), &framebufferInfo, nullptr,
                                 &this->g_swapChainFramebuffers[i]) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create framebuffer!");
+            throw fge::Exception("failed to create framebuffer!");
         }
     }
 }
@@ -416,7 +416,7 @@ void RenderWindow::createCommandBuffers()
     if (vkAllocateCommandBuffers(this->_g_context->getLogicalDevice().getDevice(), &allocInfo,
                                  this->g_commandBuffers.data()) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to allocate command buffers!");
+        throw fge::Exception("failed to allocate command buffers!");
     }
 }
 void RenderWindow::createCommandPool()
@@ -432,7 +432,7 @@ void RenderWindow::createCommandPool()
     if (vkCreateCommandPool(this->_g_context->getLogicalDevice().getDevice(), &poolInfo, nullptr,
                             &this->g_commandPool) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create command pool!");
+        throw fge::Exception("failed to create command pool!");
     }
 }
 
@@ -458,7 +458,7 @@ void RenderWindow::createSyncObjects()
             vkCreateFence(this->_g_context->getLogicalDevice().getDevice(), &fenceInfo, nullptr,
                           &this->g_inFlightFences[i]) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create semaphores!");
+            throw fge::Exception("failed to create semaphores!");
         }
     }
 }

--- a/sources/graphic/C_transform.cpp
+++ b/sources/graphic/C_transform.cpp
@@ -37,12 +37,12 @@ Transform::Transform(const fge::vulkan::Context& context) :
 }
 
 Transform::Transform(const Transform& r) :
-        g_uniformBuffer(*r.g_uniformBuffer.getContext())
+        g_uniformBuffer(r.g_uniformBuffer.getContext())
 {
-    auto const* context = r.g_uniformBuffer.getContext();
+    auto const& context = r.g_uniformBuffer.getContext();
 
-    this->g_descriptorSet = context->getTransformDescriptorPool()
-                                    .allocateDescriptorSet(context->getTransformLayout().getLayout())
+    this->g_descriptorSet = context.getTransformDescriptorPool()
+                                    .allocateDescriptorSet(context.getTransformLayout().getLayout())
                                     .value();
 
     this->g_uniformBuffer.create(fge::TransformUboData::uboSize);
@@ -74,15 +74,15 @@ Transform& Transform::operator=(const Transform& r)
 #ifndef FGE_DEF_SERVER
     if (this->g_uniformBuffer.getBuffer() == VK_NULL_HANDLE && r.g_uniformBuffer.getBuffer() != VK_NULL_HANDLE)
     {
-        auto const* context = r.g_uniformBuffer.getContext();
+        auto const& context = r.g_uniformBuffer.getContext();
 
-        if (context != this->g_uniformBuffer.getContext())
+        if (&context != &this->g_uniformBuffer.getContext())
         {
-            this->g_uniformBuffer.swapContext(*context);
+            this->g_uniformBuffer.swapContext(context);
         }
 
-        this->g_descriptorSet = context->getTransformDescriptorPool()
-                                        .allocateDescriptorSet(context->getTransformLayout().getLayout())
+        this->g_descriptorSet = context.getTransformDescriptorPool()
+                                        .allocateDescriptorSet(context.getTransformLayout().getLayout())
                                         .value();
 
         this->g_uniformBuffer.create(fge::TransformUboData::uboSize);

--- a/sources/graphic/C_transform.cpp
+++ b/sources/graphic/C_transform.cpp
@@ -154,7 +154,7 @@ const fge::vulkan::DescriptorSet& Transform::getDescriptorSet() const
 #ifndef FGE_DEF_SERVER
     return this->g_descriptorSet;
 #else
-    throw "unimplemented";
+    throw fge::Exception("unimplemented");
 #endif
 }
 const fge::vulkan::UniformBuffer& Transform::getUniformBuffer() const
@@ -162,7 +162,7 @@ const fge::vulkan::UniformBuffer& Transform::getUniformBuffer() const
 #ifndef FGE_DEF_SERVER
     return this->g_uniformBuffer;
 #else
-    throw "unimplemented";
+    throw fge::Exception("unimplemented");
 #endif
 }
 

--- a/sources/manager/anim_manager.cpp
+++ b/sources/manager/anim_manager.cpp
@@ -169,7 +169,7 @@ bool LoadFromFile(const std::string& name, std::filesystem::path path)
                 std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{std::move(buffSurface)}};
                 buffAnimData->_tilesetTexture = std::move(buffTexture);
 #else
-                std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{*vulkan::GlobalContext}};
+                std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{vulkan::GetActiveContext()}};
                 if (buffTexture->create(buffSurface.get()))
                 {
                     buffAnimData->_tilesetTexture = std::move(buffTexture);
@@ -240,7 +240,7 @@ bool LoadFromFile(const std::string& name, std::filesystem::path path)
                         std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{std::move(buffSurface)}};
                         tmpFrame._texture = std::move(buffTexture);
 #else
-                        std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{*vulkan::GlobalContext}};
+                        std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{vulkan::GetActiveContext()}};
                         if (buffTexture->create(buffSurface.get()))
                         {
                             tmpFrame._texture = std::move(buffTexture);

--- a/sources/manager/anim_manager.cpp
+++ b/sources/manager/anim_manager.cpp
@@ -169,8 +169,8 @@ bool LoadFromFile(const std::string& name, std::filesystem::path path)
                 std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{std::move(buffSurface)}};
                 buffAnimData->_tilesetTexture = std::move(buffTexture);
 #else
-                std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{}};
-                if (buffTexture->create(*vulkan::GlobalContext, buffSurface.get()))
+                std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{*vulkan::GlobalContext}};
+                if (buffTexture->create(buffSurface.get()))
                 {
                     buffAnimData->_tilesetTexture = std::move(buffTexture);
                 }
@@ -240,8 +240,8 @@ bool LoadFromFile(const std::string& name, std::filesystem::path path)
                         std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{std::move(buffSurface)}};
                         tmpFrame._texture = std::move(buffTexture);
 #else
-                        std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{}};
-                        if (buffTexture->create(*vulkan::GlobalContext, buffSurface.get()))
+                        std::shared_ptr<fge::TextureType> buffTexture{new fge::TextureType{*vulkan::GlobalContext}};
+                        if (buffTexture->create(buffSurface.get()))
                         {
                             tmpFrame._texture = std::move(buffTexture);
                         }

--- a/sources/manager/shader_manager.cpp
+++ b/sources/manager/shader_manager.cpp
@@ -408,7 +408,7 @@ FGE_API bool LoadFromMemory(std::string_view name,
             return false;
         }
 
-        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GlobalContext->getLogicalDevice(), shaderOut, type))
+        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GetActiveContext().getLogicalDevice(), shaderOut, type))
         {
             return false;
         }
@@ -424,7 +424,7 @@ FGE_API bool LoadFromMemory(std::string_view name,
         const std::vector<uint32_t> shader(reinterpret_cast<const uint32_t*>(data),
                                            reinterpret_cast<const uint32_t*>(data) + size / 4);
 
-        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GlobalContext->getLogicalDevice(), shader, type))
+        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GetActiveContext().getLogicalDevice(), shader, type))
         {
             return false;
         }
@@ -513,14 +513,14 @@ bool LoadFromFile(std::string_view name,
             return false;
         }
 
-        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GlobalContext->getLogicalDevice(), shaderOut, type))
+        if (!tmpShader.loadFromSpirVBuffer(fge::vulkan::GetActiveContext().getLogicalDevice(), shaderOut, type))
         {
             return false;
         }
     }
     break;
     case ShaderInputTypes::SHADER_SPIRV:
-        if (!tmpShader.loadFromFile(fge::vulkan::GlobalContext->getLogicalDevice(), path, type))
+        if (!tmpShader.loadFromFile(fge::vulkan::GetActiveContext().getLogicalDevice(), path, type))
         {
             return false;
         }

--- a/sources/manager/shader_manager.cpp
+++ b/sources/manager/shader_manager.cpp
@@ -302,7 +302,7 @@ fge::shader::ShaderDataType::const_iterator IteratorBegin(const std::unique_lock
 {
     if (!lock.owns_lock() || lock.mutex() != &_dataMutex)
     {
-        throw std::runtime_error("texture_manager::IteratorBegin : lock is not owned or not my mutex !");
+        throw fge::Exception("texture_manager::IteratorBegin : lock is not owned or not my mutex !");
     }
     return _dataShader.begin();
 }
@@ -310,7 +310,7 @@ fge::shader::ShaderDataType::const_iterator IteratorEnd(const std::unique_lock<s
 {
     if (!lock.owns_lock() || lock.mutex() != &_dataMutex)
     {
-        throw std::runtime_error("texture_manager::IteratorEnd : lock is not owned or not my mutex !");
+        throw fge::Exception("texture_manager::IteratorEnd : lock is not owned or not my mutex !");
     }
     return _dataShader.end();
 }

--- a/sources/manager/texture_manager.cpp
+++ b/sources/manager/texture_manager.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "FastEngine/manager/texture_manager.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include "SDL_image.h"
 #include "private/string_hash.hpp"
@@ -91,7 +92,7 @@ fge::texture::TextureDataType::const_iterator IteratorBegin(const std::unique_lo
 {
     if (!lock.owns_lock() || lock.mutex() != &_dataMutex)
     {
-        throw std::runtime_error("texture_manager::IteratorBegin : lock is not owned or not my mutex !");
+        throw fge::Exception("texture_manager::IteratorBegin : lock is not owned or not my mutex !");
     }
     return _dataTexture.begin();
 }
@@ -99,7 +100,7 @@ fge::texture::TextureDataType::const_iterator IteratorEnd(const std::unique_lock
 {
     if (!lock.owns_lock() || lock.mutex() != &_dataMutex)
     {
-        throw std::runtime_error("texture_manager::IteratorEnd : lock is not owned or not my mutex !");
+        throw fge::Exception("texture_manager::IteratorEnd : lock is not owned or not my mutex !");
     }
     return _dataTexture.end();
 }

--- a/sources/manager/texture_manager.cpp
+++ b/sources/manager/texture_manager.cpp
@@ -59,7 +59,7 @@ void Init()
 #ifdef FGE_DEF_SERVER
         _dataTextureBad->_texture = std::make_shared<fge::TextureType>(tmpSurface);
 #else
-        _dataTextureBad->_texture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
+        _dataTextureBad->_texture = std::make_shared<fge::TextureType>(vulkan::GetActiveContext());
         _dataTextureBad->_texture->create(tmpSurface.get());
 #endif //FGE_DEF_SERVER
         _dataTextureBad->_valid = false;
@@ -156,7 +156,7 @@ bool LoadFromSurface(std::string_view name, const fge::Surface& surface)
 #ifdef FGE_DEF_SERVER
     auto tmpTexture = std::make_shared<fge::TextureType>(surface);
 #else
-    auto tmpTexture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
+    auto tmpTexture = std::make_shared<fge::TextureType>(vulkan::GetActiveContext());
 
     if (!tmpTexture->create(surface.get()))
     {
@@ -193,7 +193,7 @@ bool LoadFromFile(std::string_view name, std::filesystem::path path)
         return false;
     }
 
-    auto tmpTexture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
+    auto tmpTexture = std::make_shared<fge::TextureType>(vulkan::GetActiveContext());
 
 #ifdef FGE_DEF_SERVER
     *tmpTexture = std::move(tmpSurface);

--- a/sources/manager/texture_manager.cpp
+++ b/sources/manager/texture_manager.cpp
@@ -59,8 +59,8 @@ void Init()
 #ifdef FGE_DEF_SERVER
         _dataTextureBad->_texture = std::make_shared<fge::TextureType>(tmpSurface);
 #else
-        _dataTextureBad->_texture = std::make_shared<fge::TextureType>();
-        _dataTextureBad->_texture->create(*vulkan::GlobalContext, tmpSurface.get());
+        _dataTextureBad->_texture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
+        _dataTextureBad->_texture->create(tmpSurface.get());
 #endif //FGE_DEF_SERVER
         _dataTextureBad->_valid = false;
     }
@@ -156,9 +156,9 @@ bool LoadFromSurface(std::string_view name, const fge::Surface& surface)
 #ifdef FGE_DEF_SERVER
     auto tmpTexture = std::make_shared<fge::TextureType>(surface);
 #else
-    auto tmpTexture = std::make_shared<fge::TextureType>();
+    auto tmpTexture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
 
-    if (!tmpTexture->create(*vulkan::GlobalContext, surface.get()))
+    if (!tmpTexture->create(surface.get()))
     {
         return false;
     }
@@ -193,12 +193,12 @@ bool LoadFromFile(std::string_view name, std::filesystem::path path)
         return false;
     }
 
-    auto tmpTexture = std::make_shared<fge::TextureType>();
+    auto tmpTexture = std::make_shared<fge::TextureType>(*vulkan::GlobalContext);
 
 #ifdef FGE_DEF_SERVER
     *tmpTexture = std::move(tmpSurface);
 #else
-    if (!tmpTexture->create(*vulkan::GlobalContext, tmpSurface.get()))
+    if (!tmpTexture->create(tmpSurface.get()))
     {
         return false;
     }

--- a/sources/object/C_objAnim.cpp
+++ b/sources/object/C_objAnim.cpp
@@ -20,7 +20,7 @@ namespace fge
 {
 
 ObjAnimation::ObjAnimation() :
-        g_vertices(*fge::vulkan::GlobalContext),
+        g_vertices(fge::vulkan::GetActiveContext()),
         g_tickDuration(std::chrono::milliseconds{FGE_OBJANIM_DEFAULT_TICKDURATION_MS}),
 
         g_paused(false)
@@ -29,7 +29,7 @@ ObjAnimation::ObjAnimation() :
     this->setTextureRect(this->g_animation);
 }
 ObjAnimation::ObjAnimation(const fge::Animation& animation, const fge::Vector2f& position) :
-        g_vertices(*fge::vulkan::GlobalContext),
+        g_vertices(fge::vulkan::GetActiveContext()),
         g_animation(animation),
         g_tickDuration(std::chrono::milliseconds{FGE_OBJANIM_DEFAULT_TICKDURATION_MS}),
 

--- a/sources/object/C_objAnim.cpp
+++ b/sources/object/C_objAnim.cpp
@@ -20,22 +20,22 @@ namespace fge
 {
 
 ObjAnimation::ObjAnimation() :
+        g_vertices(*fge::vulkan::GlobalContext),
         g_tickDuration(std::chrono::milliseconds{FGE_OBJANIM_DEFAULT_TICKDURATION_MS}),
 
         g_paused(false)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-                            fge::vulkan::BufferTypes::LOCAL);
+    this->g_vertices.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
     this->setTextureRect(this->g_animation);
 }
 ObjAnimation::ObjAnimation(const fge::Animation& animation, const fge::Vector2f& position) :
+        g_vertices(*fge::vulkan::GlobalContext),
         g_animation(animation),
         g_tickDuration(std::chrono::milliseconds{FGE_OBJANIM_DEFAULT_TICKDURATION_MS}),
 
         g_paused(false)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-                            fge::vulkan::BufferTypes::LOCAL);
+    this->g_vertices.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
     this->setPosition(position);
     this->setTextureRect(this->g_animation);
 }

--- a/sources/object/C_objLight.cpp
+++ b/sources/object/C_objLight.cpp
@@ -24,9 +24,10 @@
 namespace fge
 {
 
-ObjLight::ObjLight()
+ObjLight::ObjLight() :
+        g_vertexBuffer(*fge::vulkan::GlobalContext)
 {
-    this->g_vertexBuffer.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
     this->g_blendMode = fge::vulkan::BlendAlpha;
 }
 ObjLight::ObjLight(const fge::Texture& texture, const fge::Vector2f& position) :
@@ -158,7 +159,8 @@ FGE_OBJ_DRAW_BODY(ObjLight)
         const float range = (bounds._width > bounds._height) ? bounds._width : bounds._height;
         const fge::Vector2f center = bounds.getPosition() + bounds.getSize() / 2.0f;
 
-        this->g_obstacleHulls.resize(lightSystem->getGatesSize());
+        this->g_obstacleHulls.resize(lightSystem->getGatesSize(),
+                                     fge::vulkan::VertexBuffer{*fge::vulkan::GlobalContext});
 
         for (std::size_t i = 0; i < lightSystem->getGatesSize(); ++i)
         {
@@ -188,8 +190,8 @@ FGE_OBJ_DRAW_BODY(ObjLight)
             }
             fge::GetConvexHull(tmpHull, tmpHull);
 
-            this->g_obstacleHulls[i].create(*fge::vulkan::GlobalContext, tmpHull.size(),
-                                            VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN, fge::vulkan::BufferTypes::LOCAL);
+            this->g_obstacleHulls[i].create(tmpHull.size(), VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
+                                            fge::vulkan::BufferTypes::LOCAL);
             for (std::size_t a = 0; a < tmpHull.size(); ++a)
             {
                 this->g_obstacleHulls[i].getVertices()[a]._position = tmpHull[a];

--- a/sources/object/C_objLight.cpp
+++ b/sources/object/C_objLight.cpp
@@ -25,7 +25,7 @@ namespace fge
 {
 
 ObjLight::ObjLight() :
-        g_vertexBuffer(*fge::vulkan::GlobalContext)
+        g_vertexBuffer(fge::vulkan::GetActiveContext())
 {
     this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
     this->g_blendMode = fge::vulkan::BlendAlpha;
@@ -160,7 +160,7 @@ FGE_OBJ_DRAW_BODY(ObjLight)
         const fge::Vector2f center = bounds.getPosition() + bounds.getSize() / 2.0f;
 
         this->g_obstacleHulls.resize(lightSystem->getGatesSize(),
-                                     fge::vulkan::VertexBuffer{*fge::vulkan::GlobalContext});
+                                     fge::vulkan::VertexBuffer{fge::vulkan::GetActiveContext()});
 
         for (std::size_t i = 0; i < lightSystem->getGatesSize(); ++i)
         {

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -96,8 +96,6 @@ FGE_OBJ_DRAW_BODY(ObjRenderMap)
     this->_renderTexture.setView(target.getView());
     this->_renderTexture.endRenderPass();
     this->_renderTexture.display(FGE_RENDERTARGET_BAD_IMAGE_INDEX);
-    target.pushExtraCommandBuffer(this->_renderTexture.getCommandBuffers());
-    this->_renderTexture.setCurrentFrame(this->_renderTexture.getCurrentFrame() + 1);
 
     target.setView(this->g_windowView);
 

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -22,25 +22,28 @@ namespace fge
 
 ObjRenderMap::ObjRenderMap() :
         g_colorClear(fge::Color::Transparent),
+        g_vertexBuffer(*fge::vulkan::GlobalContext),
         g_windowSize(0, 0)
 {
-    this->g_vertexBuffer.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 }
 ObjRenderMap::ObjRenderMap(const fge::ObjRenderMap& r) :
         fge::Object(r),
         fge::Subscriber(r),
         g_colorClear(r.g_colorClear),
+        g_vertexBuffer(r.g_vertexBuffer.getContext()),
         g_windowSize(0, 0)
 {
-    this->g_vertexBuffer.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 }
 ObjRenderMap::ObjRenderMap(fge::ObjRenderMap& r) :
         fge::Object(r),
         fge::Subscriber(r),
         g_colorClear(r.g_colorClear),
+        g_vertexBuffer(r.g_vertexBuffer.getContext()),
         g_windowSize(0, 0)
 {
-    this->g_vertexBuffer.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 }
 
 void ObjRenderMap::onDraw([[maybe_unused]] const fge::Scene* scene, [[maybe_unused]] fge::RenderTarget& target)

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -22,7 +22,7 @@ namespace fge
 
 ObjRenderMap::ObjRenderMap() :
         g_colorClear(fge::Color::Transparent),
-        g_vertexBuffer(*fge::vulkan::GlobalContext),
+        g_vertexBuffer(fge::vulkan::GetActiveContext()),
         g_windowSize(0, 0)
 {
     this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -158,11 +158,11 @@ RectFloat ObjShape::getGlobalBounds() const
 
 ObjShape::ObjShape() :
         g_outlineThickness(0.0f),
-        g_vertices(*fge::vulkan::GlobalContext),
-        g_outlineVertices(*fge::vulkan::GlobalContext),
+        g_vertices(fge::vulkan::GetActiveContext()),
+        g_outlineVertices(fge::vulkan::GetActiveContext()),
         g_instancesCount(0),
         g_instancesCapacity(0),
-        g_instances(*fge::vulkan::GlobalContext)
+        g_instances(fge::vulkan::GetActiveContext())
 {
     this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN);
     this->g_outlineVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
@@ -387,14 +387,15 @@ void ObjShape::resizeBuffer(std::size_t size) const
 #ifndef FGE_DEF_SERVER
     if (this->g_descriptorSet.get() == VK_NULL_HANDLE)
     {
-        auto& layout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
+        auto& layout = fge::vulkan::GetActiveContext().getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
         if (layout.getLayout() == VK_NULL_HANDLE)
         {
             layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                                                   VK_SHADER_STAGE_VERTEX_BIT)});
         }
 
-        this->g_descriptorSet = fge::vulkan::GlobalContext->getMultiUseDescriptorPool()
+        this->g_descriptorSet = fge::vulkan::GetActiveContext()
+                                        .getMultiUseDescriptorPool()
                                         .allocateDescriptorSet(layout.getLayout())
                                         .value();
     }

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -158,12 +158,14 @@ RectFloat ObjShape::getGlobalBounds() const
 
 ObjShape::ObjShape() :
         g_outlineThickness(0.0f),
+        g_vertices(*fge::vulkan::GlobalContext),
+        g_outlineVertices(*fge::vulkan::GlobalContext),
         g_instancesCount(0),
         g_instancesCapacity(0),
         g_instances(*fge::vulkan::GlobalContext)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN);
-    this->g_outlineVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN);
+    this->g_outlineVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 
     this->resizeBuffer(1);
     *this->retrieveInstance(0) = {{fge::Color::White, fge::Color::White}, {0.0f, 0.0f}};

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -24,8 +24,8 @@ namespace
 {
 
 #ifndef FGE_DEF_SERVER
-void InstanceVertexShader_constructor(const fge::vulkan::Context* context,
-                                      const fge::RenderTarget::GraphicPipelineKey& key,
+void InstanceVertexShader_constructor(fge::vulkan::Context const& context,
+                                      fge::RenderTarget::GraphicPipelineKey const& key,
                                       fge::vulkan::GraphicPipeline* graphicPipeline)
 {
     graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_NOTEXTURE_FRAGMENT)->_shader);
@@ -35,14 +35,14 @@ void InstanceVertexShader_constructor(const fge::vulkan::Context* context,
 
     graphicPipeline->setPushConstantRanges({VkPushConstantRange{VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::uint)}});
 
-    auto& layout = context->getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
+    auto& layout = context.getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
         layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                                               VK_SHADER_STAGE_VERTEX_BIT)});
     }
 
-    graphicPipeline->setDescriptorSetLayouts({context->getTransformLayout().getLayout(), layout.getLayout()});
+    graphicPipeline->setDescriptorSetLayouts({context.getTransformLayout().getLayout(), layout.getLayout()});
 }
 #endif
 

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -177,7 +177,7 @@ ObjShape::ObjShape(const ObjShape& r) :
         g_outlineVertices(r.g_outlineVertices),
         g_instancesCount(0),
         g_instancesCapacity(0),
-        g_instances(*r.g_instances.getContext()),
+        g_instances(r.g_instances.getContext()),
         g_insideBounds(r.g_insideBounds),
         g_bounds(r.g_bounds)
 {

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -159,7 +159,8 @@ RectFloat ObjShape::getGlobalBounds() const
 ObjShape::ObjShape() :
         g_outlineThickness(0.0f),
         g_instancesCount(0),
-        g_instancesCapacity(0)
+        g_instancesCapacity(0),
+        g_instances(*fge::vulkan::GlobalContext)
 {
     this->g_vertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN);
     this->g_outlineVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
@@ -176,6 +177,7 @@ ObjShape::ObjShape(const ObjShape& r) :
         g_outlineVertices(r.g_outlineVertices),
         g_instancesCount(0),
         g_instancesCapacity(0),
+        g_instances(*r.g_instances.getContext()),
         g_insideBounds(r.g_insideBounds),
         g_bounds(r.g_bounds)
 {
@@ -378,8 +380,7 @@ void ObjShape::resizeBuffer(std::size_t size) const
 
     this->g_instancesCount = size;
     this->g_instancesCapacity = size;
-    this->g_instances.create(*fge::vulkan::GlobalContext,
-                             static_cast<VkDeviceSize>(this->g_instancesCapacity) * sizeof(InstanceData), true);
+    this->g_instances.create(static_cast<VkDeviceSize>(this->g_instancesCapacity) * sizeof(InstanceData), true);
 
 #ifndef FGE_DEF_SERVER
     if (this->g_descriptorSet.get() == VK_NULL_HANDLE)

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -38,8 +38,8 @@ void InstanceVertexShader_constructor(const fge::vulkan::Context* context,
     auto& layout = context->getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
-        layout.create(*context, {fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                                                                        VK_SHADER_STAGE_VERTEX_BIT)});
+        layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                                              VK_SHADER_STAGE_VERTEX_BIT)});
     }
 
     graphicPipeline->setDescriptorSetLayouts({context->getTransformLayout().getLayout(), layout.getLayout()});
@@ -387,8 +387,7 @@ void ObjShape::resizeBuffer(std::size_t size) const
         auto& layout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSHAPE_INSTANCES_LAYOUT);
         if (layout.getLayout() == VK_NULL_HANDLE)
         {
-            layout.create(*fge::vulkan::GlobalContext,
-                          {fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                                                   VK_SHADER_STAGE_VERTEX_BIT)});
         }
 

--- a/sources/object/C_objSprite.cpp
+++ b/sources/object/C_objSprite.cpp
@@ -20,7 +20,7 @@ namespace fge
 {
 
 ObjSprite::ObjSprite() :
-        g_vertices(*fge::vulkan::GlobalContext)
+        g_vertices(fge::vulkan::GetActiveContext())
 {
     this->g_vertices.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
 }

--- a/sources/object/C_objSprite.cpp
+++ b/sources/object/C_objSprite.cpp
@@ -19,10 +19,10 @@
 namespace fge
 {
 
-ObjSprite::ObjSprite()
+ObjSprite::ObjSprite() :
+        g_vertices(*fge::vulkan::GlobalContext)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-                            fge::vulkan::BufferTypes::LOCAL);
+    this->g_vertices.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
 }
 ObjSprite::ObjSprite(const fge::Texture& texture, const fge::Vector2f& position) :
         ObjSprite()

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -81,6 +81,7 @@ void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* conte
 
 ObjSpriteBatches::ObjSpriteBatches() :
         g_instancesTransformDataCapacity(0),
+        g_instancesTransform(*fge::vulkan::GlobalContext),
         g_needBuffersUpdate(true)
 {
     this->g_instancesVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
@@ -91,6 +92,7 @@ ObjSpriteBatches::ObjSpriteBatches(const ObjSpriteBatches& r) :
         g_textures(r.g_textures),
         g_instancesData(r.g_instancesData),
         g_instancesTransformDataCapacity(0),
+        g_instancesTransform(*r.g_instancesTransform.getContext()),
         g_instancesVertices(r.g_instancesVertices),
         g_needBuffersUpdate(true)
 {}
@@ -413,8 +415,7 @@ void ObjSpriteBatches::updateBuffers() const
         {
             this->g_instancesTransformDataCapacity = this->g_instancesData.size();
 
-            this->g_instancesTransform.create(*fge::vulkan::GlobalContext,
-                                              sizeof(InstanceDataBuffer) * (this->g_instancesData.size() + 1), true);
+            this->g_instancesTransform.create(sizeof(InstanceDataBuffer) * (this->g_instancesData.size() + 1), true);
 
             const fge::vulkan::DescriptorSet::Descriptor descriptor{
                     this->g_instancesTransform, 0, fge::vulkan::DescriptorSet::Descriptor::BufferTypes::STORAGE,

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -27,8 +27,8 @@ namespace
 {
 
 #ifndef FGE_DEF_SERVER
-void DefaultGraphicPipelineBatchesWithTexture_constructor(const fge::vulkan::Context* context,
-                                                          const fge::RenderTarget::GraphicPipelineKey& key,
+void DefaultGraphicPipelineBatchesWithTexture_constructor(fge::vulkan::Context const& context,
+                                                          fge::RenderTarget::GraphicPipelineKey const& key,
                                                           fge::vulkan::GraphicPipeline* graphicPipeline)
 {
     graphicPipeline->setShader(fge::shader::GetShader(FGE_OBJSPRITEBATCHES_SHADER_FRAGMENT)->_shader);
@@ -36,7 +36,7 @@ void DefaultGraphicPipelineBatchesWithTexture_constructor(const fge::vulkan::Con
     graphicPipeline->setBlendMode(key._blendMode);
     graphicPipeline->setPrimitiveTopology(key._topology);
 
-    auto& layout = context->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
+    auto& layout = context.getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
         layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
@@ -57,8 +57,8 @@ void DefaultGraphicPipelineBatchesWithTexture_constructor(const fge::vulkan::Con
 
     graphicPipeline->setDescriptorSetLayouts({layout.getLayout(), textureLayout.getLayout()});
 }
-void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* context,
-                                               const fge::RenderTarget::GraphicPipelineKey& key,
+void DefaultGraphicPipelineBatches_constructor(fge::vulkan::Context const& context,
+                                               fge::RenderTarget::GraphicPipelineKey const& key,
                                                fge::vulkan::GraphicPipeline* graphicPipeline)
 {
     graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_NOTEXTURE_FRAGMENT)->_shader); ///TODO
@@ -66,7 +66,7 @@ void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* conte
     graphicPipeline->setBlendMode(key._blendMode);
     graphicPipeline->setPrimitiveTopology(key._topology);
 
-    auto& layout = context->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
+    auto& layout = context.getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
         layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -82,10 +82,10 @@ void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* conte
 ObjSpriteBatches::ObjSpriteBatches() :
         g_instancesTransformDataCapacity(0),
         g_instancesTransform(*fge::vulkan::GlobalContext),
+        g_instancesVertices(*fge::vulkan::GlobalContext),
         g_needBuffersUpdate(true)
 {
-    this->g_instancesVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
-                                     fge::vulkan::BufferTypes::LOCAL);
+    this->g_instancesVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
 }
 ObjSpriteBatches::ObjSpriteBatches(const ObjSpriteBatches& r) :
         fge::Object(r),

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -39,16 +39,15 @@ void DefaultGraphicPipelineBatchesWithTexture_constructor(const fge::vulkan::Con
     auto& layout = context->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
-        layout.create(*context, {fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                                                                        VK_SHADER_STAGE_VERTEX_BIT)});
+        layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                                              VK_SHADER_STAGE_VERTEX_BIT)});
     }
 
     auto& textureLayout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT_TEXTURES);
     if (textureLayout.getLayout() == VK_NULL_HANDLE)
     {
         VkDescriptorBindingFlagsEXT const bindingFlags[] = {VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT_EXT};
-        textureLayout.create(*fge::vulkan::GlobalContext,
-                             {VkDescriptorSetLayoutBinding{.binding = 0,
+        textureLayout.create({VkDescriptorSetLayoutBinding{.binding = 0,
                                                            .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                                            .descriptorCount = FGE_OBJSPRITEBATCHES_MAXIMUM_TEXTURES,
                                                            .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -70,8 +69,8 @@ void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* conte
     auto& layout = context->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
     if (layout.getLayout() == VK_NULL_HANDLE)
     {
-        layout.create(*context, {fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                                                                        VK_SHADER_STAGE_VERTEX_BIT)});
+        layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                                              VK_SHADER_STAGE_VERTEX_BIT)});
     }
 
     graphicPipeline->setDescriptorSetLayouts({layout.getLayout()});
@@ -400,8 +399,7 @@ void ObjSpriteBatches::updateBuffers() const
             auto& layout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
             if (layout.getLayout() == VK_NULL_HANDLE)
             {
-                layout.create(*fge::vulkan::GlobalContext,
-                              {fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                                                       VK_SHADER_STAGE_VERTEX_BIT)});
             }
 
@@ -434,8 +432,7 @@ void ObjSpriteBatches::updateTextures(bool sizeHasChanged)
         {
             VkDescriptorBindingFlagsEXT const bindingFlags[] = {
                     VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT_EXT};
-            layout.create(*fge::vulkan::GlobalContext,
-                          {VkDescriptorSetLayoutBinding{.binding = 0,
+            layout.create({VkDescriptorSetLayoutBinding{.binding = 0,
                                                         .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                                         .descriptorCount = FGE_OBJSPRITEBATCHES_MAXIMUM_TEXTURES,
                                                         .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -43,7 +43,7 @@ void DefaultGraphicPipelineBatchesWithTexture_constructor(const fge::vulkan::Con
                                                               VK_SHADER_STAGE_VERTEX_BIT)});
     }
 
-    auto& textureLayout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT_TEXTURES);
+    auto& textureLayout = fge::vulkan::GetActiveContext().getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT_TEXTURES);
     if (textureLayout.getLayout() == VK_NULL_HANDLE)
     {
         VkDescriptorBindingFlagsEXT const bindingFlags[] = {VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT_EXT};
@@ -81,8 +81,8 @@ void DefaultGraphicPipelineBatches_constructor(const fge::vulkan::Context* conte
 
 ObjSpriteBatches::ObjSpriteBatches() :
         g_instancesTransformDataCapacity(0),
-        g_instancesTransform(*fge::vulkan::GlobalContext),
-        g_instancesVertices(*fge::vulkan::GlobalContext),
+        g_instancesTransform(fge::vulkan::GetActiveContext()),
+        g_instancesVertices(fge::vulkan::GetActiveContext()),
         g_needBuffersUpdate(true)
 {
     this->g_instancesVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, fge::vulkan::BufferTypes::LOCAL);
@@ -398,7 +398,7 @@ void ObjSpriteBatches::updateBuffers() const
 
         if (this->g_descriptorSets[FGE_OBJSPRITEBATCHES_DESCRIPTORSET_INSTANCES].get() == VK_NULL_HANDLE)
         {
-            auto& layout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
+            auto& layout = fge::vulkan::GetActiveContext().getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT);
             if (layout.getLayout() == VK_NULL_HANDLE)
             {
                 layout.create({fge::vulkan::CreateSimpleLayoutBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
@@ -406,7 +406,8 @@ void ObjSpriteBatches::updateBuffers() const
             }
 
             this->g_descriptorSets[FGE_OBJSPRITEBATCHES_DESCRIPTORSET_INSTANCES] =
-                    fge::vulkan::GlobalContext->getMultiUseDescriptorPool()
+                    fge::vulkan::GetActiveContext()
+                            .getMultiUseDescriptorPool()
                             .allocateDescriptorSet(layout.getLayout())
                             .value();
         }
@@ -428,7 +429,7 @@ void ObjSpriteBatches::updateTextures(bool sizeHasChanged)
 {
     if (sizeHasChanged || this->g_descriptorSets[FGE_OBJSPRITEBATCHES_DESCRIPTORSET_TEXTURES].get() == VK_NULL_HANDLE)
     {
-        auto& layout = fge::vulkan::GlobalContext->getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT_TEXTURES);
+        auto& layout = fge::vulkan::GetActiveContext().getCacheLayout(FGE_OBJSPRITEBATCHES_LAYOUT_TEXTURES);
         if (layout.getLayout() == VK_NULL_HANDLE)
         {
             VkDescriptorBindingFlagsEXT const bindingFlags[] = {
@@ -442,7 +443,8 @@ void ObjSpriteBatches::updateTextures(bool sizeHasChanged)
         }
 
         this->g_descriptorSets[FGE_OBJSPRITEBATCHES_DESCRIPTORSET_TEXTURES] =
-                fge::vulkan::GlobalContext->getMultiUseDescriptorPool()
+                fge::vulkan::GetActiveContext()
+                        .getMultiUseDescriptorPool()
                         .allocateDescriptorSet(layout.getLayout(), this->g_textures.size())
                         .value();
     }

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -92,7 +92,7 @@ ObjSpriteBatches::ObjSpriteBatches(const ObjSpriteBatches& r) :
         g_textures(r.g_textures),
         g_instancesData(r.g_instancesData),
         g_instancesTransformDataCapacity(0),
-        g_instancesTransform(*r.g_instancesTransform.getContext()),
+        g_instancesTransform(r.g_instancesTransform.getContext()),
         g_instancesVertices(r.g_instancesVertices),
         g_needBuffersUpdate(true)
 {}

--- a/sources/object/C_objSpriteCluster.cpp
+++ b/sources/object/C_objSpriteCluster.cpp
@@ -19,10 +19,10 @@
 namespace fge
 {
 
-ObjSpriteCluster::ObjSpriteCluster()
+ObjSpriteCluster::ObjSpriteCluster() :
+        g_instancesVertices(*fge::vulkan::GlobalContext)
 {
-    this->g_instancesVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-                                     fge::vulkan::BufferTypes::LOCAL);
+    this->g_instancesVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
 }
 ObjSpriteCluster::ObjSpriteCluster(const ObjSpriteCluster& r) :
         fge::Object(r),

--- a/sources/object/C_objSpriteCluster.cpp
+++ b/sources/object/C_objSpriteCluster.cpp
@@ -20,7 +20,7 @@ namespace fge
 {
 
 ObjSpriteCluster::ObjSpriteCluster() :
-        g_instancesVertices(*fge::vulkan::GlobalContext)
+        g_instancesVertices(fge::vulkan::GetActiveContext())
 {
     this->g_instancesVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
 }

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -22,21 +22,21 @@
 namespace fge
 {
 
-Character::Character()
+Character::Character() :
+        g_vertices(*fge::vulkan::GlobalContext),
+        g_outlineVertices(*fge::vulkan::GlobalContext)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-                            fge::vulkan::BufferTypes::LOCAL);
-    this->g_outlineVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-                                   fge::vulkan::BufferTypes::LOCAL);
+    this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
+    this->g_outlineVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
 }
 Character::Character(const fge::Color& fillColor, const fge::Color& outlineColor) :
+        g_vertices(*fge::vulkan::GlobalContext),
+        g_outlineVertices(*fge::vulkan::GlobalContext),
         g_fillColor(fillColor),
         g_outlineColor(outlineColor)
 {
-    this->g_vertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-                            fge::vulkan::BufferTypes::LOCAL);
-    this->g_outlineVertices.create(*fge::vulkan::GlobalContext, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
-                                   fge::vulkan::BufferTypes::LOCAL);
+    this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
+    this->g_outlineVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
 }
 
 void Character::clear()

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -23,15 +23,15 @@ namespace fge
 {
 
 Character::Character() :
-        g_vertices(*fge::vulkan::GlobalContext),
-        g_outlineVertices(*fge::vulkan::GlobalContext)
+        g_vertices(fge::vulkan::GetActiveContext()),
+        g_outlineVertices(fge::vulkan::GetActiveContext())
 {
     this->g_vertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
     this->g_outlineVertices.create(0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, fge::vulkan::BufferTypes::LOCAL);
 }
 Character::Character(const fge::Color& fillColor, const fge::Color& outlineColor) :
-        g_vertices(*fge::vulkan::GlobalContext),
-        g_outlineVertices(*fge::vulkan::GlobalContext),
+        g_vertices(fge::vulkan::GetActiveContext()),
+        g_outlineVertices(fge::vulkan::GetActiveContext()),
         g_fillColor(fillColor),
         g_outlineColor(outlineColor)
 {

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "FastEngine/vulkan/C_context.hpp"
-#include "SDL_events.h"
 #include <iostream>
 #include <optional>
 #include <vector>
@@ -28,8 +27,11 @@ namespace fge::vulkan
 {
 
 Context::Context() :
-        g_textureDescriptorPool(),
-        g_transformDescriptorPool(),
+        g_multiUseDescriptorPool(*this),
+        g_textureLayout(*this),
+        g_transformLayout(*this),
+        g_textureDescriptorPool(*this),
+        g_transformDescriptorPool(*this),
         g_commandPool(VK_NULL_HANDLE),
         g_isCreated(false)
 {}
@@ -444,7 +446,7 @@ void Context::createMultiUseDescriptorPool()
     poolSizes[2].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
     poolSizes[2].descriptorCount = 1;
 
-    this->g_multiUseDescriptorPool.create(*this, std::move(poolSizes), 128, false, true);
+    this->g_multiUseDescriptorPool.create(std::move(poolSizes), 128, false, true);
 }
 void Context::createTextureDescriptorPool()
 {
@@ -452,7 +454,7 @@ void Context::createTextureDescriptorPool()
     poolSizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     poolSizes[0].descriptorCount = 1;
 
-    this->g_textureDescriptorPool.create(*this, std::move(poolSizes), 128, false, true);
+    this->g_textureDescriptorPool.create(std::move(poolSizes), 128, false, true);
 }
 void Context::createTransformDescriptorPool()
 {
@@ -460,7 +462,7 @@ void Context::createTransformDescriptorPool()
     poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     poolSizes[0].descriptorCount = 1;
 
-    this->g_transformDescriptorPool.create(*this, std::move(poolSizes), 128, false, true);
+    this->g_transformDescriptorPool.create(std::move(poolSizes), 128, false, true);
 }
 
 } // namespace fge::vulkan

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -176,21 +176,33 @@ void Context::initVulkan(SDL_Window* window)
 }
 void Context::enumerateExtensions()
 {
-#ifdef FGE_DEF_DEBUG
+    auto extensions = Context::retrieveExtensions();
+
+    std::cout << "available extensions:\n";
+
+    for (auto const& extension: extensions)
+    {
+        std::cout << '\t' << extension << '\n';
+    }
+    std::cout << std::flush;
+}
+std::vector<std::string> Context::retrieveExtensions()
+{
     uint32_t extensionCount = 0;
     vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
 
     std::vector<VkExtensionProperties> extensions(extensionCount);
     vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensions.data());
 
-    std::cout << "available extensions:\n";
+    std::vector<std::string> result;
+    result.reserve(extensionCount);
 
-    for (const auto& extension: extensions)
+    for (auto const& extension: extensions)
     {
-        std::cout << '\t' << extension.extensionName << '\n';
+        result.emplace_back(extension.extensionName);
     }
-    std::cout << std::endl;
-#endif
+
+    return result;
 }
 
 void Context::waitIdle()

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -167,12 +167,10 @@ void Context::initVulkan(SDL_Window* window)
     this->createTextureDescriptorPool();
     this->createTransformDescriptorPool();
 
-    this->g_textureLayout.create(*this, {fge::vulkan::CreateSimpleLayoutBinding(
-                                                FGE_VULKAN_TEXTURE_BINDING, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                VK_SHADER_STAGE_FRAGMENT_BIT)});
-    this->g_transformLayout.create(*this, {fge::vulkan::CreateSimpleLayoutBinding(FGE_VULKAN_TRANSFORM_BINDING,
-                                                                                  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                                                                                  VK_SHADER_STAGE_VERTEX_BIT)});
+    this->g_textureLayout.create({fge::vulkan::CreateSimpleLayoutBinding(
+            FGE_VULKAN_TEXTURE_BINDING, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)});
+    this->g_transformLayout.create({fge::vulkan::CreateSimpleLayoutBinding(
+            FGE_VULKAN_TRANSFORM_BINDING, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT)});
 }
 void Context::enumerateExtensions()
 {
@@ -389,7 +387,9 @@ fge::vulkan::DescriptorSetLayout& Context::getCacheLayout(std::string_view key) 
     {
         return it->second;
     }
-    return this->g_cacheLayouts[std::string(key)];
+    return this->g_cacheLayouts
+            .emplace(std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(*this))
+            .first->second;
 }
 const DescriptorPool& Context::getMultiUseDescriptorPool() const
 {

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -452,6 +452,19 @@ VmaAllocator Context::getAllocator() const
     return this->g_allocator;
 }
 
+void Context::pushGraphicsCommandBuffer(VkCommandBuffer commandBuffer) const
+{
+    this->g_executableGraphicsCommandBuffers.push_back(commandBuffer);
+}
+std::vector<VkCommandBuffer> const& Context::getGraphicsCommandBuffers() const
+{
+    return this->g_executableGraphicsCommandBuffers;
+}
+void Context::clearGraphicsCommandBuffers() const
+{
+    this->g_executableGraphicsCommandBuffers.clear();
+}
+
 void Context::createCommandPool()
 {
     auto queueFamilyIndices = this->g_physicalDevice.findQueueFamilies(this->g_surface.getSurface());

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -104,7 +104,7 @@ void Context::initVolk()
     auto result = volkInitialize();
     if (result != VK_SUCCESS)
     {
-        throw std::runtime_error{"Can't init volk!"};
+        throw fge::Exception{"Can't init volk!"};
     }
 }
 
@@ -118,7 +118,7 @@ void Context::initVulkan(SDL_Window* window)
     this->g_physicalDevice = this->g_instance.pickPhysicalDevice(this->g_surface.getSurface());
     if (this->g_physicalDevice.getDevice() == VK_NULL_HANDLE)
     {
-        throw std::runtime_error("failed to find a suitable GPU!");
+        throw fge::Exception("failed to find a suitable GPU!");
     }
     this->g_logicalDevice.create(this->g_physicalDevice, this->g_surface.getSurface());
 
@@ -161,7 +161,7 @@ void Context::initVulkan(SDL_Window* window)
 
     if (vmaCreateAllocator(&allocatorCreateInfo, &this->g_allocator) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create allocator!");
+        throw fge::Exception("failed to create allocator!");
     }
 
     this->createCommandPool();
@@ -295,7 +295,7 @@ void Context::transitionImageLayout(VkImage image,
     }
     else
     {
-        throw std::invalid_argument("unsupported layout transition!");
+        throw fge::Exception("unsupported layout transition!");
     }
 
     vkCmdPipelineBarrier(commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
@@ -431,7 +431,7 @@ void Context::createCommandPool()
 
     if (vkCreateCommandPool(this->g_logicalDevice.getDevice(), &poolInfo, nullptr, &this->g_commandPool) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create command pool!");
+        throw fge::Exception("failed to create command pool!");
     }
 }
 void Context::createMultiUseDescriptorPool()

--- a/sources/vulkan/C_descriptorPool.cpp
+++ b/sources/vulkan/C_descriptorPool.cpp
@@ -22,39 +22,34 @@
 namespace fge::vulkan
 {
 
-DescriptorPool::DescriptorPool() :
+DescriptorPool::DescriptorPool(Context const& context) :
+        ContextAware(context),
         g_maxSetsPerPool(0),
         g_isUnique(false),
         g_isCreated(false),
-        g_individuallyFree(true),
-
-        g_context(nullptr)
+        g_individuallyFree(true)
 {}
 DescriptorPool::DescriptorPool(DescriptorPool&& r) noexcept :
+        ContextAware(static_cast<ContextAware&&>(r)),
         g_descriptorPoolSizes(std::move(r.g_descriptorPoolSizes)),
 
         g_maxSetsPerPool(r.g_maxSetsPerPool),
         g_descriptorPools(std::move(r.g_descriptorPools)),
         g_isUnique(r.g_isUnique),
         g_isCreated(r.g_isCreated),
-        g_individuallyFree(r.g_individuallyFree),
-
-        g_context(r.g_context)
+        g_individuallyFree(r.g_individuallyFree)
 {
     r.g_maxSetsPerPool = 0;
     r.g_isUnique = false;
     r.g_isCreated = false;
     r.g_individuallyFree = true;
-
-    r.g_context = nullptr;
 }
 DescriptorPool::~DescriptorPool()
 {
     this->destroy();
 }
 
-void DescriptorPool::create(const Context& context,
-                            std::vector<VkDescriptorPoolSize>&& descriptorPoolSizes,
+void DescriptorPool::create(std::vector<VkDescriptorPoolSize>&& descriptorPoolSizes,
                             uint32_t maxSetsPerPool,
                             bool isUnique,
                             bool individuallyFree)
@@ -67,8 +62,6 @@ void DescriptorPool::create(const Context& context,
     this->g_individuallyFree = individuallyFree;
     ///TODO: if false, need to reset pools when they reach count=0
 
-    this->g_context = &context;
-
     this->g_descriptorPoolSizes = std::move(descriptorPoolSizes);
     this->g_descriptorPools.push_back(this->createPool());
 }
@@ -80,7 +73,7 @@ void DescriptorPool::destroy()
 
         for (auto& pool: this->g_descriptorPools)
         {
-            vkDestroyDescriptorPool(this->g_context->getLogicalDevice().getDevice(), pool._pool, nullptr);
+            vkDestroyDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), pool._pool, nullptr);
         }
         this->g_descriptorPools.clear();
 
@@ -88,8 +81,6 @@ void DescriptorPool::destroy()
         this->g_isUnique = false;
         this->g_isCreated = false;
         this->g_individuallyFree = true;
-
-        this->g_context = nullptr;
     }
 }
 
@@ -124,8 +115,8 @@ void DescriptorPool::destroy()
     {
         allocInfo.descriptorPool = pool._pool;
 
-        auto result =
-                vkAllocateDescriptorSets(this->g_context->getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
+        auto result = vkAllocateDescriptorSets(this->getContext()->getLogicalDevice().getDevice(), &allocInfo,
+                                               &descriptorSet);
         if (result != VK_SUCCESS)
         {
             if (result == VK_ERROR_FRAGMENTED_POOL || result == VK_ERROR_OUT_OF_POOL_MEMORY)
@@ -146,7 +137,7 @@ void DescriptorPool::destroy()
         this->g_descriptorPools.push_back(this->createPool());
         allocInfo.descriptorPool = this->g_descriptorPools.back()._pool;
         descriptorPool = this->g_descriptorPools.back()._pool;
-        vkAllocateDescriptorSets(this->g_context->getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
+        vkAllocateDescriptorSets(this->getContext()->getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
     }
 
     //Last check for a valid descriptor set
@@ -174,22 +165,22 @@ void DescriptorPool::freeDescriptorSet(VkDescriptorSet descriptorSet, VkDescript
                 return;
             }
 
-            this->g_context->_garbageCollector.push(GarbageDescriptorSet(
-                    descriptorSet, descriptorPool, this->g_context->getLogicalDevice().getDevice()));
+            this->getContext()->_garbageCollector.push(GarbageDescriptorSet(
+                    descriptorSet, descriptorPool, this->getContext()->getLogicalDevice().getDevice()));
             --pool._count;
             return;
         }
     }
 
     //Should never happen, but in order to avoid memory leaks, we free the descriptor set anyway
-    this->g_context->_garbageCollector.push(
-            GarbageDescriptorSet(descriptorSet, descriptorPool, this->g_context->getLogicalDevice().getDevice()));
+    this->getContext()->_garbageCollector.push(
+            GarbageDescriptorSet(descriptorSet, descriptorPool, this->getContext()->getLogicalDevice().getDevice()));
 }
 void DescriptorPool::resetPools() const
 {
     for (auto& pool: this->g_descriptorPools)
     {
-        if (vkResetDescriptorPool(this->g_context->getLogicalDevice().getDevice(), pool._pool, 0) != VK_SUCCESS)
+        if (vkResetDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), pool._pool, 0) != VK_SUCCESS)
         {
             throw std::runtime_error("failed to reset descriptor pool!");
         }
@@ -209,10 +200,6 @@ bool DescriptorPool::isCreated() const
 {
     return this->g_isCreated;
 }
-const Context* DescriptorPool::getContext() const
-{
-    return this->g_context;
-}
 
 DescriptorPool::Pool DescriptorPool::createPool() const
 {
@@ -224,7 +211,7 @@ DescriptorPool::Pool DescriptorPool::createPool() const
     poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
 
     VkDescriptorPool pool;
-    if (vkCreateDescriptorPool(this->g_context->getLogicalDevice().getDevice(), &poolInfo, nullptr, &pool) !=
+    if (vkCreateDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), &poolInfo, nullptr, &pool) !=
         VK_SUCCESS)
     {
         throw std::runtime_error("failed to create descriptor pool!");

--- a/sources/vulkan/C_descriptorPool.cpp
+++ b/sources/vulkan/C_descriptorPool.cpp
@@ -73,7 +73,7 @@ void DescriptorPool::destroy()
 
         for (auto& pool: this->g_descriptorPools)
         {
-            vkDestroyDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), pool._pool, nullptr);
+            vkDestroyDescriptorPool(this->getContext().getLogicalDevice().getDevice(), pool._pool, nullptr);
         }
         this->g_descriptorPools.clear();
 
@@ -115,8 +115,8 @@ void DescriptorPool::destroy()
     {
         allocInfo.descriptorPool = pool._pool;
 
-        auto result = vkAllocateDescriptorSets(this->getContext()->getLogicalDevice().getDevice(), &allocInfo,
-                                               &descriptorSet);
+        auto result =
+                vkAllocateDescriptorSets(this->getContext().getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
         if (result != VK_SUCCESS)
         {
             if (result == VK_ERROR_FRAGMENTED_POOL || result == VK_ERROR_OUT_OF_POOL_MEMORY)
@@ -137,7 +137,7 @@ void DescriptorPool::destroy()
         this->g_descriptorPools.push_back(this->createPool());
         allocInfo.descriptorPool = this->g_descriptorPools.back()._pool;
         descriptorPool = this->g_descriptorPools.back()._pool;
-        vkAllocateDescriptorSets(this->getContext()->getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
+        vkAllocateDescriptorSets(this->getContext().getLogicalDevice().getDevice(), &allocInfo, &descriptorSet);
     }
 
     //Last check for a valid descriptor set
@@ -165,22 +165,22 @@ void DescriptorPool::freeDescriptorSet(VkDescriptorSet descriptorSet, VkDescript
                 return;
             }
 
-            this->getContext()->_garbageCollector.push(GarbageDescriptorSet(
-                    descriptorSet, descriptorPool, this->getContext()->getLogicalDevice().getDevice()));
+            this->getContext()._garbageCollector.push(GarbageDescriptorSet(
+                    descriptorSet, descriptorPool, this->getContext().getLogicalDevice().getDevice()));
             --pool._count;
             return;
         }
     }
 
     //Should never happen, but in order to avoid memory leaks, we free the descriptor set anyway
-    this->getContext()->_garbageCollector.push(
-            GarbageDescriptorSet(descriptorSet, descriptorPool, this->getContext()->getLogicalDevice().getDevice()));
+    this->getContext()._garbageCollector.push(
+            GarbageDescriptorSet(descriptorSet, descriptorPool, this->getContext().getLogicalDevice().getDevice()));
 }
 void DescriptorPool::resetPools() const
 {
     for (auto& pool: this->g_descriptorPools)
     {
-        if (vkResetDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), pool._pool, 0) != VK_SUCCESS)
+        if (vkResetDescriptorPool(this->getContext().getLogicalDevice().getDevice(), pool._pool, 0) != VK_SUCCESS)
         {
             throw std::runtime_error("failed to reset descriptor pool!");
         }
@@ -211,7 +211,7 @@ DescriptorPool::Pool DescriptorPool::createPool() const
     poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
 
     VkDescriptorPool pool;
-    if (vkCreateDescriptorPool(this->getContext()->getLogicalDevice().getDevice(), &poolInfo, nullptr, &pool) !=
+    if (vkCreateDescriptorPool(this->getContext().getLogicalDevice().getDevice(), &poolInfo, nullptr, &pool) !=
         VK_SUCCESS)
     {
         throw std::runtime_error("failed to create descriptor pool!");

--- a/sources/vulkan/C_descriptorPool.cpp
+++ b/sources/vulkan/C_descriptorPool.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "FastEngine/vulkan/C_descriptorPool.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/C_descriptorSet.hpp"
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -182,7 +182,7 @@ void DescriptorPool::resetPools() const
     {
         if (vkResetDescriptorPool(this->getContext().getLogicalDevice().getDevice(), pool._pool, 0) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to reset descriptor pool!");
+            throw fge::Exception("failed to reset descriptor pool!");
         }
         pool._count = 0;
     }
@@ -214,7 +214,7 @@ DescriptorPool::Pool DescriptorPool::createPool() const
     if (vkCreateDescriptorPool(this->getContext().getLogicalDevice().getDevice(), &poolInfo, nullptr, &pool) !=
         VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create descriptor pool!");
+        throw fge::Exception("failed to create descriptor pool!");
     }
 
     return {pool, 0};

--- a/sources/vulkan/C_descriptorSet.cpp
+++ b/sources/vulkan/C_descriptorSet.cpp
@@ -118,11 +118,11 @@ DescriptorSet& DescriptorSet::operator=(DescriptorSet&& r) noexcept
 {
     return this->g_pool;
 }
-[[nodiscard]] const Context* DescriptorSet::getContext() const
+[[nodiscard]] Context const* DescriptorSet::getContext() const
 {
     if (this->g_pool != nullptr)
     {
-        return this->g_pool->getContext();
+        return &this->g_pool->getContext();
     }
     return nullptr;
 }
@@ -174,7 +174,7 @@ void DescriptorSet::updateDescriptorSet(const Descriptor* descriptors, std::size
         }
     }
 
-    vkUpdateDescriptorSets(this->g_pool->getContext()->getLogicalDevice().getDevice(), descriptorWrites.size(),
+    vkUpdateDescriptorSets(this->g_pool->getContext().getLogicalDevice().getDevice(), descriptorWrites.size(),
                            descriptorWrites.data(), 0, nullptr);
 }
 

--- a/sources/vulkan/C_descriptorSetLayout.cpp
+++ b/sources/vulkan/C_descriptorSetLayout.cpp
@@ -21,17 +21,16 @@
 namespace fge::vulkan
 {
 
-DescriptorSetLayout::DescriptorSetLayout() :
-        g_descriptorSetLayout(VK_NULL_HANDLE),
-        g_context(nullptr)
+DescriptorSetLayout::DescriptorSetLayout(Context const& context) :
+        ContextAware(context),
+        g_descriptorSetLayout(VK_NULL_HANDLE)
 {}
 DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& r) noexcept :
+        ContextAware(r),
         g_descriptorSetLayout(r.g_descriptorSetLayout),
-        g_bindings(std::move(r.g_bindings)),
-        g_context(r.g_context)
+        g_bindings(std::move(r.g_bindings))
 {
     r.g_descriptorSetLayout = VK_NULL_HANDLE;
-    r.g_context = nullptr;
 }
 DescriptorSetLayout::~DescriptorSetLayout()
 {
@@ -42,18 +41,16 @@ DescriptorSetLayout& DescriptorSetLayout::operator=(DescriptorSetLayout&& r) noe
 {
     this->destroy();
 
+    ContextAware::operator=(r);
     this->g_bindings = std::move(r.g_bindings);
-    this->g_context = r.g_context;
     this->g_descriptorSetLayout = r.g_descriptorSetLayout;
 
     r.g_descriptorSetLayout = VK_NULL_HANDLE;
-    r.g_context = nullptr;
 
     return *this;
 }
 
-void DescriptorSetLayout::create(const Context& context,
-                                 std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
+void DescriptorSetLayout::create(std::initializer_list<VkDescriptorSetLayoutBinding> bindings,
                                  VkDescriptorBindingFlagsEXT const* bindingFlags)
 {
     this->destroy();
@@ -64,7 +61,6 @@ void DescriptorSetLayout::create(const Context& context,
     }
 
     this->g_bindings = bindings;
-    this->g_context = &context;
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -81,7 +77,7 @@ void DescriptorSetLayout::create(const Context& context,
         layoutInfo.pNext = &bindingFlagsInfo;
     }
 
-    if (vkCreateDescriptorSetLayout(this->g_context->getLogicalDevice().getDevice(), &layoutInfo, nullptr,
+    if (vkCreateDescriptorSetLayout(this->_g_context->getLogicalDevice().getDevice(), &layoutInfo, nullptr,
                                     &this->g_descriptorSetLayout) != VK_SUCCESS)
     {
         throw std::runtime_error("failed to create descriptor set layout!");
@@ -91,11 +87,10 @@ void DescriptorSetLayout::destroy()
 {
     if (this->g_descriptorSetLayout != VK_NULL_HANDLE)
     {
-        vkDestroyDescriptorSetLayout(this->g_context->getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
+        vkDestroyDescriptorSetLayout(this->_g_context->getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
                                      nullptr);
         this->g_descriptorSetLayout = VK_NULL_HANDLE;
         this->g_bindings.clear();
-        this->g_context = nullptr;
     }
 }
 
@@ -110,10 +105,6 @@ const std::vector<VkDescriptorSetLayoutBinding>& DescriptorSetLayout::getBinding
 std::size_t DescriptorSetLayout::getBindingsCount() const
 {
     return this->g_bindings.size();
-}
-const Context* DescriptorSetLayout::getContext() const
-{
-    return this->g_context;
 }
 
 } // namespace fge::vulkan

--- a/sources/vulkan/C_descriptorSetLayout.cpp
+++ b/sources/vulkan/C_descriptorSetLayout.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "FastEngine/vulkan/C_descriptorSetLayout.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -81,7 +81,7 @@ void DescriptorSetLayout::create(std::initializer_list<VkDescriptorSetLayoutBind
     if (vkCreateDescriptorSetLayout(this->getContext().getLogicalDevice().getDevice(), &layoutInfo, nullptr,
                                     &this->g_descriptorSetLayout) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create descriptor set layout!");
+        throw fge::Exception("failed to create descriptor set layout!");
     }
 }
 void DescriptorSetLayout::destroy()

--- a/sources/vulkan/C_descriptorSetLayout.cpp
+++ b/sources/vulkan/C_descriptorSetLayout.cpp
@@ -78,7 +78,7 @@ void DescriptorSetLayout::create(std::initializer_list<VkDescriptorSetLayoutBind
         layoutInfo.pNext = &bindingFlagsInfo;
     }
 
-    if (vkCreateDescriptorSetLayout(this->getContext()->getLogicalDevice().getDevice(), &layoutInfo, nullptr,
+    if (vkCreateDescriptorSetLayout(this->getContext().getLogicalDevice().getDevice(), &layoutInfo, nullptr,
                                     &this->g_descriptorSetLayout) != VK_SUCCESS)
     {
         throw std::runtime_error("failed to create descriptor set layout!");
@@ -88,7 +88,7 @@ void DescriptorSetLayout::destroy()
 {
     if (this->g_descriptorSetLayout != VK_NULL_HANDLE)
     {
-        vkDestroyDescriptorSetLayout(this->getContext()->getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
+        vkDestroyDescriptorSetLayout(this->getContext().getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
                                      nullptr);
         this->g_descriptorSetLayout = VK_NULL_HANDLE;
         this->g_bindings.clear();

--- a/sources/vulkan/C_descriptorSetLayout.cpp
+++ b/sources/vulkan/C_descriptorSetLayout.cpp
@@ -26,7 +26,7 @@ DescriptorSetLayout::DescriptorSetLayout(Context const& context) :
         g_descriptorSetLayout(VK_NULL_HANDLE)
 {}
 DescriptorSetLayout::DescriptorSetLayout(DescriptorSetLayout&& r) noexcept :
-        ContextAware(r),
+        ContextAware(static_cast<ContextAware&&>(r)),
         g_descriptorSetLayout(r.g_descriptorSetLayout),
         g_bindings(std::move(r.g_bindings))
 {
@@ -39,9 +39,10 @@ DescriptorSetLayout::~DescriptorSetLayout()
 
 DescriptorSetLayout& DescriptorSetLayout::operator=(DescriptorSetLayout&& r) noexcept
 {
+    this->verifyContext(r);
+
     this->destroy();
 
-    ContextAware::operator=(r);
     this->g_bindings = std::move(r.g_bindings);
     this->g_descriptorSetLayout = r.g_descriptorSetLayout;
 
@@ -77,7 +78,7 @@ void DescriptorSetLayout::create(std::initializer_list<VkDescriptorSetLayoutBind
         layoutInfo.pNext = &bindingFlagsInfo;
     }
 
-    if (vkCreateDescriptorSetLayout(this->_g_context->getLogicalDevice().getDevice(), &layoutInfo, nullptr,
+    if (vkCreateDescriptorSetLayout(this->getContext()->getLogicalDevice().getDevice(), &layoutInfo, nullptr,
                                     &this->g_descriptorSetLayout) != VK_SUCCESS)
     {
         throw std::runtime_error("failed to create descriptor set layout!");
@@ -87,7 +88,7 @@ void DescriptorSetLayout::destroy()
 {
     if (this->g_descriptorSetLayout != VK_NULL_HANDLE)
     {
-        vkDestroyDescriptorSetLayout(this->_g_context->getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
+        vkDestroyDescriptorSetLayout(this->getContext()->getLogicalDevice().getDevice(), this->g_descriptorSetLayout,
                                      nullptr);
         this->g_descriptorSetLayout = VK_NULL_HANDLE;
         this->g_bindings.clear();

--- a/sources/vulkan/C_garbageCollector.cpp
+++ b/sources/vulkan/C_garbageCollector.cpp
@@ -45,6 +45,10 @@ Garbage::~Garbage()
     case GarbageType::GARBAGE_COMMAND_POOL:
         vkDestroyCommandPool(this->g_data._commandPool._logicalDevice, this->g_data._commandPool._commandPool, nullptr);
         break;
+    case GarbageType::GARBAGE_COMMAND_BUFFER:
+        vkFreeCommandBuffers(this->g_data._commandBuffer._logicalDevice, this->g_data._commandBuffer._commandPool, 1,
+                             &this->g_data._commandBuffer._commandBuffer);
+        break;
     case GarbageType::GARBAGE_FRAMEBUFFER:
         vkDestroyFramebuffer(this->g_data._framebuffer._logicalDevice, this->g_data._framebuffer._framebuffer, nullptr);
         break;

--- a/sources/vulkan/C_graphicPipeline.cpp
+++ b/sources/vulkan/C_graphicPipeline.cpp
@@ -233,7 +233,7 @@ bool GraphicPipeline::updateIfNeeded(VkRenderPass renderPass, bool force) const
         if (vkCreateGraphicsPipelines(this->getContext().getLogicalDevice().getDevice(), VK_NULL_HANDLE, 1,
                                       &pipelineInfo, nullptr, &this->g_graphicsPipeline) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create graphics pipeline!");
+            throw fge::Exception("failed to create graphics pipeline!");
         }
 
         return true;
@@ -468,7 +468,7 @@ void GraphicPipeline::updatePipelineLayout() const
         if (vkCreatePipelineLayout(this->getContext().getLogicalDevice().getDevice(), &pipelineLayoutInfo, nullptr,
                                    &this->g_pipelineLayout) != VK_SUCCESS)
         {
-            throw std::runtime_error("failed to create pipeline layout!");
+            throw fge::Exception("failed to create pipeline layout!");
         }
     }
 }

--- a/sources/vulkan/C_graphicPipeline.cpp
+++ b/sources/vulkan/C_graphicPipeline.cpp
@@ -230,7 +230,7 @@ bool GraphicPipeline::updateIfNeeded(VkRenderPass renderPass, bool force) const
         pipelineInfo.basePipelineHandle = VK_NULL_HANDLE; // Optional
         pipelineInfo.basePipelineIndex = -1;              // Optional
 
-        if (vkCreateGraphicsPipelines(this->getContext()->getLogicalDevice().getDevice(), VK_NULL_HANDLE, 1,
+        if (vkCreateGraphicsPipelines(this->getContext().getLogicalDevice().getDevice(), VK_NULL_HANDLE, 1,
                                       &pipelineInfo, nullptr, &this->g_graphicsPipeline) != VK_SUCCESS)
         {
             throw std::runtime_error("failed to create graphics pipeline!");
@@ -465,7 +465,7 @@ void GraphicPipeline::updatePipelineLayout() const
         pipelineLayoutInfo.pushConstantRangeCount = this->g_pushConstantRanges.size();
         pipelineLayoutInfo.pPushConstantRanges = this->g_pushConstantRanges.data();
 
-        if (vkCreatePipelineLayout(this->getContext()->getLogicalDevice().getDevice(), &pipelineLayoutInfo, nullptr,
+        if (vkCreatePipelineLayout(this->getContext().getLogicalDevice().getDevice(), &pipelineLayoutInfo, nullptr,
                                    &this->g_pipelineLayout) != VK_SUCCESS)
         {
             throw std::runtime_error("failed to create pipeline layout!");
@@ -477,8 +477,8 @@ void GraphicPipeline::cleanPipelineLayout() const
 {
     if (this->g_pipelineLayout != VK_NULL_HANDLE)
     {
-        this->getContext()->_garbageCollector.push(
-                GarbagePipelineLayout(this->g_pipelineLayout, this->getContext()->getLogicalDevice().getDevice()));
+        this->getContext()._garbageCollector.push(
+                GarbagePipelineLayout(this->g_pipelineLayout, this->getContext().getLogicalDevice().getDevice()));
 
         this->g_pipelineLayout = VK_NULL_HANDLE;
     }
@@ -487,8 +487,8 @@ void GraphicPipeline::cleanPipeline() const
 {
     if (this->g_graphicsPipeline != VK_NULL_HANDLE)
     {
-        this->getContext()->_garbageCollector.push(
-                GarbageGraphicPipeline(this->g_graphicsPipeline, this->getContext()->getLogicalDevice().getDevice()));
+        this->getContext()._garbageCollector.push(
+                GarbageGraphicPipeline(this->g_graphicsPipeline, this->getContext().getLogicalDevice().getDevice()));
 
         this->g_graphicsPipeline = VK_NULL_HANDLE;
     }

--- a/sources/vulkan/C_instance.cpp
+++ b/sources/vulkan/C_instance.cpp
@@ -16,10 +16,10 @@
 
 #include "FastEngine/vulkan/C_instance.hpp"
 #include "FastEngine/fastengine_version.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include <iostream>
 #include <map>
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -50,7 +50,7 @@ void Instance::create(SDL_Window* window,
 {
     if (this->g_instance != VK_NULL_HANDLE)
     {
-        throw std::runtime_error{"instance already created !"};
+        throw fge::Exception{"instance already created !"};
     }
 
     this->g_applicationName = std::move(applicationName);
@@ -104,7 +104,7 @@ void Instance::create(SDL_Window* window,
 
     if (result != VK_SUCCESS)
     {
-        throw std::runtime_error{"error while creating instance !"};
+        throw fge::Exception{"error while creating instance !"};
     }
 
     volkLoadInstance(this->g_instance);
@@ -177,7 +177,7 @@ void Instance::enumeratePhysicalDevices()
 
     if (deviceCount == 0)
     {
-        throw std::runtime_error("failed to find GPUs with Vulkan support !");
+        throw fge::Exception("failed to find GPUs with Vulkan support !");
     }
 
     std::vector<VkPhysicalDevice> physicalDevices(deviceCount);

--- a/sources/vulkan/C_logicalDevice.cpp
+++ b/sources/vulkan/C_logicalDevice.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "FastEngine/vulkan/C_logicalDevice.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_physicalDevice.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
-#include <stdexcept>
 #include <vector>
 
 namespace fge::vulkan
@@ -111,7 +111,7 @@ void LogicalDevice::create(PhysicalDevice& physicalDevice, VkSurfaceKHR surface)
 
     if (vkCreateDevice(physicalDevice.getDevice(), &createInfo, nullptr, &this->g_device) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create logical device!");
+        throw fge::Exception("failed to create logical device!");
     }
 
     vkGetDeviceQueue(this->g_device, indices._graphicsFamily.value(), 0, &this->g_graphicQueue);

--- a/sources/vulkan/C_physicalDevice.cpp
+++ b/sources/vulkan/C_physicalDevice.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "FastEngine/vulkan/C_physicalDevice.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #ifdef FGE_DEF_DEBUG
     #include <iostream>
 #endif
 #include <set>
-#include <stdexcept>
 #include <string>
 
 namespace fge::vulkan
@@ -224,7 +224,7 @@ uint32_t PhysicalDevice::findMemoryType(uint32_t typeFilter, VkMemoryPropertyFla
         }
     }
 
-    throw std::runtime_error("failed to find suitable memory type!");
+    throw fge::Exception("failed to find suitable memory type!");
 }
 
 uint32_t PhysicalDevice::getMaxImageDimension2D() const

--- a/sources/vulkan/C_surface.cpp
+++ b/sources/vulkan/C_surface.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "FastEngine/vulkan/C_surface.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_instance.hpp"
 #include "SDL_vulkan.h"
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -42,7 +42,7 @@ void Surface::create(Instance& instance)
 {
     if (SDL_Vulkan_CreateSurface(instance.getWindow(), instance.getInstance(), &this->g_surface) == SDL_FALSE)
     {
-        throw std::runtime_error("failed to create surface !");
+        throw fge::Exception("failed to create surface !");
     }
 
     this->g_instance = &instance;
@@ -53,7 +53,7 @@ void Surface::destroy()
     {
         if (this->g_instance->getInstance() == VK_NULL_HANDLE)
         {
-            throw std::runtime_error("surface must be destroyed before the instance !");
+            throw fge::Exception("surface must be destroyed before the instance !");
         }
         vkDestroySurfaceKHR(this->g_instance->getInstance(), this->g_surface, nullptr);
         this->g_surface = VK_NULL_HANDLE;

--- a/sources/vulkan/C_swapChain.cpp
+++ b/sources/vulkan/C_swapChain.cpp
@@ -15,13 +15,13 @@
  */
 
 #include "FastEngine/vulkan/C_swapChain.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_logicalDevice.hpp"
 #include "FastEngine/vulkan/C_physicalDevice.hpp"
 #include "FastEngine/vulkan/C_surface.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include <algorithm>
 #include <limits>
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -108,7 +108,7 @@ void SwapChain::create(SDL_Window* window,
 
     if (vkCreateSwapchainKHR(logicalDevice.getDevice(), &createInfo, nullptr, &this->g_swapChain) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create swap chain!");
+        throw fge::Exception("failed to create swap chain!");
     }
 
     vkGetSwapchainImagesKHR(logicalDevice.getDevice(), this->g_swapChain, &imageCount, nullptr);

--- a/sources/vulkan/C_textureImage.cpp
+++ b/sources/vulkan/C_textureImage.cpp
@@ -15,10 +15,10 @@
  */
 
 #include "FastEngine/vulkan/C_textureImage.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include <cstring>
-#include <stdexcept>
 
 #define FGE_VULKAN_TEXTUREIMAGE_FORMAT VK_FORMAT_R8G8B8A8_UNORM
 
@@ -543,7 +543,7 @@ void TextureImage::createTextureSampler()
     if (vkCreateSampler(this->getContext().getLogicalDevice().getDevice(), &samplerInfo, nullptr,
                         &this->g_textureSampler) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create texture sampler!");
+        throw fge::Exception("failed to create texture sampler!");
     }
 }
 

--- a/sources/vulkan/C_textureImage.cpp
+++ b/sources/vulkan/C_textureImage.cpp
@@ -25,7 +25,8 @@
 namespace fge::vulkan
 {
 
-TextureImage::TextureImage() :
+TextureImage::TextureImage(Context const& context) :
+        ContextAware(context),
         g_textureImage(VK_NULL_HANDLE),
         g_textureImageAllocation(VK_NULL_HANDLE),
 
@@ -38,11 +39,10 @@ TextureImage::TextureImage() :
         g_filter(VK_FILTER_NEAREST),
         g_normalizedCoordinates(true),
 
-        g_modificationCount(0),
-
-        g_context(nullptr)
+        g_modificationCount(0)
 {}
 TextureImage::TextureImage(TextureImage&& r) noexcept :
+        ContextAware(static_cast<ContextAware&&>(r)),
         g_textureImage(r.g_textureImage),
         g_textureImageAllocation(r.g_textureImageAllocation),
 
@@ -57,9 +57,7 @@ TextureImage::TextureImage(TextureImage&& r) noexcept :
 
         g_textureDescriptorSet(std::move(r.g_textureDescriptorSet)),
 
-        g_modificationCount(r.g_modificationCount),
-
-        g_context(r.g_context)
+        g_modificationCount(r.g_modificationCount)
 {
     r.g_textureImage = VK_NULL_HANDLE;
     r.g_textureImageAllocation = VK_NULL_HANDLE;
@@ -74,8 +72,6 @@ TextureImage::TextureImage(TextureImage&& r) noexcept :
     r.g_normalizedCoordinates = false;
 
     r.g_modificationCount = 0;
-
-    r.g_context = nullptr;
 }
 TextureImage::~TextureImage()
 {
@@ -84,6 +80,8 @@ TextureImage::~TextureImage()
 
 TextureImage& TextureImage::operator=(TextureImage&& r) noexcept
 {
+    this->verifyContext(r);
+
     this->destroy();
 
     this->g_textureImage = r.g_textureImage;
@@ -102,8 +100,6 @@ TextureImage& TextureImage::operator=(TextureImage&& r) noexcept
 
     ++this->g_modificationCount;
 
-    this->g_context = r.g_context;
-
     r.g_textureImage = VK_NULL_HANDLE;
     r.g_textureImageAllocation = VK_NULL_HANDLE;
 
@@ -118,11 +114,10 @@ TextureImage& TextureImage::operator=(TextureImage&& r) noexcept
 
     r.g_modificationCount = 0;
 
-    r.g_context = nullptr;
     return *this;
 }
 
-bool TextureImage::create(const Context& context, const glm::vec<2, int>& size)
+bool TextureImage::create(const glm::vec<2, int>& size)
 {
     this->destroy();
 
@@ -133,7 +128,7 @@ bool TextureImage::create(const Context& context, const glm::vec<2, int>& size)
         return false;
     }
 
-    this->g_context = &context;
+    auto* context = this->getContext();
 
     const VkDeviceSize imageSize = static_cast<VkDeviceSize>(size.x) * size.y * 4;
 
@@ -143,45 +138,45 @@ bool TextureImage::create(const Context& context, const glm::vec<2, int>& size)
     VkBuffer stagingBuffer = VK_NULL_HANDLE;
     VmaAllocation stagingBufferAllocation = VK_NULL_HANDLE;
 
-    CreateBuffer(context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+    CreateBuffer(*context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stagingBuffer,
                  stagingBufferAllocation);
 
     std::vector<uint8_t> pixels(imageSize, 0);
 
     void* data = nullptr;
-    vmaMapMemory(this->g_context->getAllocator(), stagingBufferAllocation, &data);
+    vmaMapMemory(context->getAllocator(), stagingBufferAllocation, &data);
     memcpy(data, pixels.data(), static_cast<size_t>(imageSize));
-    vmaUnmapMemory(this->g_context->getAllocator(), stagingBufferAllocation);
+    vmaUnmapMemory(context->getAllocator(), stagingBufferAllocation);
 
-    CreateImage(context, size.x, size.y, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_TILING_OPTIMAL,
+    CreateImage(*context, size.x, size.y, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_TILING_OPTIMAL,
                 VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
                         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_textureImage, this->g_textureImageAllocation);
 
-    context.transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_LAYOUT_UNDEFINED,
-                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-    context.copyBufferToImage(stagingBuffer, this->g_textureImage, static_cast<uint32_t>(size.x),
-                              static_cast<uint32_t>(size.y));
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_LAYOUT_UNDEFINED,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    context->copyBufferToImage(stagingBuffer, this->g_textureImage, static_cast<uint32_t>(size.x),
+                               static_cast<uint32_t>(size.y));
 
-    context.transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-    vmaDestroyBuffer(context.getAllocator(), stagingBuffer, stagingBufferAllocation);
+    vmaDestroyBuffer(context->getAllocator(), stagingBuffer, stagingBufferAllocation);
 
     this->g_textureImageView =
-            CreateImageView(context.getLogicalDevice(), this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT);
+            CreateImageView(context->getLogicalDevice(), this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT);
 
-    this->createTextureSampler(context.getPhysicalDevice());
+    this->createTextureSampler();
 
     this->g_textureDescriptorSet =
-            context.getTextureDescriptorPool().allocateDescriptorSet(context.getTextureLayout().getLayout()).value();
+            context->getTextureDescriptorPool().allocateDescriptorSet(context->getTextureLayout().getLayout()).value();
 
     const DescriptorSet::Descriptor descriptor(*this, FGE_VULKAN_TEXTURE_BINDING);
     this->g_textureDescriptorSet.updateDescriptorSet(&descriptor, 1);
     return true;
 }
-bool TextureImage::create(const Context& context, SDL_Surface* surface)
+bool TextureImage::create(SDL_Surface* surface)
 {
     this->destroy();
 
@@ -192,7 +187,7 @@ bool TextureImage::create(const Context& context, SDL_Surface* surface)
         return false;
     }
 
-    this->g_context = &context;
+    auto* context = this->getContext();
 
     const VkDeviceSize imageSize = static_cast<VkDeviceSize>(surface->w) * surface->h * surface->format->BytesPerPixel;
 
@@ -202,37 +197,37 @@ bool TextureImage::create(const Context& context, SDL_Surface* surface)
     VkBuffer stagingBuffer = VK_NULL_HANDLE;
     VmaAllocation stagingBufferAllocation = VK_NULL_HANDLE;
 
-    CreateBuffer(context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+    CreateBuffer(*context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stagingBuffer,
                  stagingBufferAllocation);
 
     void* data = nullptr;
-    vmaMapMemory(this->g_context->getAllocator(), stagingBufferAllocation, &data);
+    vmaMapMemory(context->getAllocator(), stagingBufferAllocation, &data);
     memcpy(data, surface->pixels, static_cast<size_t>(imageSize));
-    vmaUnmapMemory(this->g_context->getAllocator(), stagingBufferAllocation);
+    vmaUnmapMemory(context->getAllocator(), stagingBufferAllocation);
 
-    CreateImage(context, surface->w, surface->h, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_TILING_OPTIMAL,
+    CreateImage(*context, surface->w, surface->h, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_TILING_OPTIMAL,
                 VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
                         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_textureImage, this->g_textureImageAllocation);
 
-    context.transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_LAYOUT_UNDEFINED,
-                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-    context.copyBufferToImage(stagingBuffer, this->g_textureImage, static_cast<uint32_t>(surface->w),
-                              static_cast<uint32_t>(surface->h));
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT, VK_IMAGE_LAYOUT_UNDEFINED,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    context->copyBufferToImage(stagingBuffer, this->g_textureImage, static_cast<uint32_t>(surface->w),
+                               static_cast<uint32_t>(surface->h));
 
-    context.transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-    vmaDestroyBuffer(context.getAllocator(), stagingBuffer, stagingBufferAllocation);
+    vmaDestroyBuffer(context->getAllocator(), stagingBuffer, stagingBufferAllocation);
 
     this->g_textureImageView =
-            CreateImageView(context.getLogicalDevice(), this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT);
+            CreateImageView(context->getLogicalDevice(), this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT);
 
-    this->createTextureSampler(context.getPhysicalDevice());
+    this->createTextureSampler();
 
     this->g_textureDescriptorSet =
-            context.getTextureDescriptorPool().allocateDescriptorSet(context.getTextureLayout().getLayout()).value();
+            context->getTextureDescriptorPool().allocateDescriptorSet(context->getTextureLayout().getLayout()).value();
 
     const DescriptorSet::Descriptor descriptor(*this, FGE_VULKAN_TEXTURE_BINDING);
     this->g_textureDescriptorSet.updateDescriptorSet(&descriptor, 1);
@@ -244,11 +239,11 @@ void TextureImage::destroy()
     {
         this->g_textureDescriptorSet.destroy();
 
-        this->g_context->_garbageCollector.push(
-                fge::vulkan::GarbageSampler(this->g_textureSampler, this->g_context->getLogicalDevice().getDevice()));
+        this->getContext()->_garbageCollector.push(fge::vulkan::GarbageSampler(
+                this->g_textureSampler, this->getContext()->getLogicalDevice().getDevice()));
 
-        this->g_context->_garbageCollector.push(fge::vulkan::GarbageImage(
-                this->g_textureImage, this->g_textureImageAllocation, this->g_textureImageView, this->g_context));
+        this->getContext()->_garbageCollector.push(fge::vulkan::GarbageImage(
+                this->g_textureImage, this->g_textureImageAllocation, this->g_textureImageView, this->getContext()));
 
         this->g_textureImageView = VK_NULL_HANDLE;
 
@@ -261,8 +256,6 @@ void TextureImage::destroy()
         this->g_filter = VK_FILTER_NEAREST;
 
         this->g_modificationCount = 0;
-
-        this->g_context = nullptr;
     }
 }
 
@@ -286,26 +279,26 @@ SDL_Surface* TextureImage::copyToSurface() const
     VkBuffer dstBuffer = VK_NULL_HANDLE;
     VmaAllocation dstBufferAllocation = VK_NULL_HANDLE;
 
-    CreateBuffer(*this->g_context, imageSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+    auto* context = this->getContext();
+
+    CreateBuffer(*context, imageSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, dstBuffer,
                  dstBufferAllocation);
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
-    this->g_context->copyImageToBuffer(this->g_textureImage, dstBuffer, this->g_textureSize.x, this->g_textureSize.y);
+    context->copyImageToBuffer(this->g_textureImage, dstBuffer, this->g_textureSize.x, this->g_textureSize.y);
 
     void* data = nullptr;
-    vmaMapMemory(this->g_context->getAllocator(), dstBufferAllocation, &data);
+    vmaMapMemory(context->getAllocator(), dstBufferAllocation, &data);
     memcpy(surface->pixels, data, static_cast<size_t>(imageSize));
-    vmaUnmapMemory(this->g_context->getAllocator(), dstBufferAllocation);
+    vmaUnmapMemory(context->getAllocator(), dstBufferAllocation);
 
-    vmaDestroyBuffer(this->g_context->getAllocator(), dstBuffer, dstBufferAllocation);
+    vmaDestroyBuffer(context->getAllocator(), dstBuffer, dstBufferAllocation);
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     return surface;
 }
@@ -323,31 +316,31 @@ void TextureImage::update(SDL_Surface* surface, const glm::vec<2, int>& offset)
 
     ++this->g_modificationCount;
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    auto* context = this->getContext();
+
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const VkDeviceSize imageSize = static_cast<VkDeviceSize>(surface->w) * surface->h * surface->format->BytesPerPixel;
 
     VkBuffer stagingBuffer = VK_NULL_HANDLE;
     VmaAllocation stagingBufferAllocation = VK_NULL_HANDLE;
 
-    CreateBuffer(*this->g_context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+    CreateBuffer(*context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stagingBuffer,
                  stagingBufferAllocation);
 
     void* data = nullptr;
-    vmaMapMemory(this->g_context->getAllocator(), stagingBufferAllocation, &data);
+    vmaMapMemory(context->getAllocator(), stagingBufferAllocation, &data);
     memcpy(data, surface->pixels, static_cast<size_t>(imageSize));
-    vmaUnmapMemory(this->g_context->getAllocator(), stagingBufferAllocation);
+    vmaUnmapMemory(context->getAllocator(), stagingBufferAllocation);
 
-    this->g_context->copyBufferToImage(stagingBuffer, this->g_textureImage, surface->w, surface->h, offset.x, offset.y);
+    context->copyBufferToImage(stagingBuffer, this->g_textureImage, surface->w, surface->h, offset.x, offset.y);
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-    vmaDestroyBuffer(this->g_context->getAllocator(), stagingBuffer, stagingBufferAllocation);
+    vmaDestroyBuffer(context->getAllocator(), stagingBuffer, stagingBufferAllocation);
 }
 void TextureImage::update(const TextureImage& textureImage, const glm::vec<2, int>& offset)
 {
@@ -363,22 +356,20 @@ void TextureImage::update(const TextureImage& textureImage, const glm::vec<2, in
 
     ++this->g_modificationCount;
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-    this->g_context->transitionImageLayout(textureImage.g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    auto* context = this->getContext();
 
-    this->g_context->copyImageToImage(textureImage.g_textureImage, this->g_textureImage, textureImage.g_textureSize.x,
-                                      textureImage.g_textureSize.y, offset.x, offset.y);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    context->transitionImageLayout(textureImage.g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-    this->g_context->transitionImageLayout(textureImage.g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->copyImageToImage(textureImage.g_textureImage, this->g_textureImage, textureImage.g_textureSize.x,
+                              textureImage.g_textureSize.y, offset.x, offset.y);
+
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(textureImage.g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 }
 void TextureImage::update(void* buffer,
                           std::size_t bufferSize,
@@ -396,31 +387,31 @@ void TextureImage::update(void* buffer,
 
     ++this->g_modificationCount;
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    auto* context = this->getContext();
+
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const VkDeviceSize imageSize = bufferSize;
 
     VkBuffer stagingBuffer = VK_NULL_HANDLE;
     VmaAllocation stagingBufferAllocation = VK_NULL_HANDLE;
 
-    CreateBuffer(*this->g_context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+    CreateBuffer(*context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, stagingBuffer,
                  stagingBufferAllocation);
 
     void* data = nullptr;
-    vmaMapMemory(this->g_context->getAllocator(), stagingBufferAllocation, &data);
+    vmaMapMemory(context->getAllocator(), stagingBufferAllocation, &data);
     memcpy(data, buffer, bufferSize);
-    vmaUnmapMemory(this->g_context->getAllocator(), stagingBufferAllocation);
+    vmaUnmapMemory(context->getAllocator(), stagingBufferAllocation);
 
-    this->g_context->copyBufferToImage(stagingBuffer, this->g_textureImage, size.x, size.y, offset.x, offset.y);
+    context->copyBufferToImage(stagingBuffer, this->g_textureImage, size.x, size.y, offset.x, offset.y);
 
-    this->g_context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
-                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    context->transitionImageLayout(this->g_textureImage, FGE_VULKAN_TEXTUREIMAGE_FORMAT,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
-    vmaDestroyBuffer(this->g_context->getAllocator(), stagingBuffer, stagingBufferAllocation);
+    vmaDestroyBuffer(context->getAllocator(), stagingBuffer, stagingBufferAllocation);
 }
 
 const glm::vec<2, int>& TextureImage::getSize() const
@@ -459,9 +450,9 @@ void TextureImage::setNormalizedCoordinates(bool normalized)
     if (this->g_normalizedCoordinates != normalized)
     {
         this->g_normalizedCoordinates = normalized;
-        this->g_context->_garbageCollector.push(
-                fge::vulkan::GarbageSampler(this->g_textureSampler, this->g_context->getLogicalDevice().getDevice()));
-        this->createTextureSampler(this->g_context->getPhysicalDevice());
+        this->getContext()->_garbageCollector.push(fge::vulkan::GarbageSampler(
+                this->g_textureSampler, this->getContext()->getLogicalDevice().getDevice()));
+        this->createTextureSampler();
 
         const DescriptorSet::Descriptor descriptor(*this, FGE_VULKAN_TEXTURE_BINDING);
         this->g_textureDescriptorSet.updateDescriptorSet(&descriptor, 1);
@@ -477,9 +468,9 @@ void TextureImage::setFilter(VkFilter filter)
     if (this->g_filter != filter)
     {
         this->g_filter = filter;
-        this->g_context->_garbageCollector.push(
-                fge::vulkan::GarbageSampler(this->g_textureSampler, this->g_context->getLogicalDevice().getDevice()));
-        this->createTextureSampler(this->g_context->getPhysicalDevice());
+        this->getContext()->_garbageCollector.push(fge::vulkan::GarbageSampler(
+                this->g_textureSampler, this->getContext()->getLogicalDevice().getDevice()));
+        this->createTextureSampler();
 
         const DescriptorSet::Descriptor descriptor(*this, FGE_VULKAN_TEXTURE_BINDING);
         this->g_textureDescriptorSet.updateDescriptorSet(&descriptor, 1);
@@ -488,11 +479,6 @@ void TextureImage::setFilter(VkFilter filter)
 VkFilter TextureImage::getFilter() const
 {
     return this->g_filter;
-}
-
-const Context* TextureImage::getContext() const
-{
-    return this->g_context;
 }
 
 const fge::vulkan::DescriptorSet& TextureImage::getDescriptorSet() const
@@ -527,7 +513,7 @@ uint32_t TextureImage::getModificationCount() const
     return this->g_modificationCount;
 }
 
-void TextureImage::createTextureSampler(const PhysicalDevice& physicalDevice)
+void TextureImage::createTextureSampler()
 {
     VkSamplerCreateInfo samplerInfo{};
     samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -538,7 +524,7 @@ void TextureImage::createTextureSampler(const PhysicalDevice& physicalDevice)
     samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
 
     VkPhysicalDeviceProperties properties{};
-    vkGetPhysicalDeviceProperties(physicalDevice.getDevice(), &properties);
+    vkGetPhysicalDeviceProperties(this->getContext()->getPhysicalDevice().getDevice(), &properties);
 
     samplerInfo.anisotropyEnable = VK_TRUE;
     samplerInfo.maxAnisotropy = properties.limits.maxSamplerAnisotropy;
@@ -554,7 +540,7 @@ void TextureImage::createTextureSampler(const PhysicalDevice& physicalDevice)
     samplerInfo.minLod = 0.0f;
     samplerInfo.maxLod = 0.0f;
 
-    if (vkCreateSampler(this->g_context->getLogicalDevice().getDevice(), &samplerInfo, nullptr,
+    if (vkCreateSampler(this->getContext()->getLogicalDevice().getDevice(), &samplerInfo, nullptr,
                         &this->g_textureSampler) != VK_SUCCESS)
     {
         throw std::runtime_error("failed to create texture sampler!");

--- a/sources/vulkan/C_uniformBuffer.cpp
+++ b/sources/vulkan/C_uniformBuffer.cpp
@@ -34,7 +34,7 @@ UniformBuffer::UniformBuffer(Context const& context) :
 #endif
 {}
 UniformBuffer::UniformBuffer([[maybe_unused]] const UniformBuffer& r) : ///TODO: better copy
-        UniformBuffer(*r.getContext())
+        UniformBuffer(r.getContext())
 {}
 UniformBuffer::UniformBuffer(UniformBuffer&& r) noexcept :
         ContextAware(static_cast<ContextAware&&>(r)),
@@ -73,14 +73,14 @@ void UniformBuffer::create(VkDeviceSize bufferSize, [[maybe_unused]] bool isStor
 #else
     this->destroy();
 
-    CreateBuffer(*this->getContext(), bufferSize,
+    CreateBuffer(this->getContext(), bufferSize,
                  isStorageBuffer ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT : VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, this->g_uniformBuffer,
                  this->g_uniformBufferAllocation);
 
     this->g_bufferSize = bufferSize;
 
-    vmaMapMemory(this->getContext()->getAllocator(), this->g_uniformBufferAllocation, &this->g_uniformBufferMapped);
+    vmaMapMemory(this->getContext().getAllocator(), this->g_uniformBufferAllocation, &this->g_uniformBufferMapped);
 #endif
 }
 void UniformBuffer::destroy()
@@ -90,9 +90,9 @@ void UniformBuffer::destroy()
 #else
     if (this->g_uniformBuffer != VK_NULL_HANDLE)
     {
-        vmaUnmapMemory(this->getContext()->getAllocator(), this->g_uniformBufferAllocation);
-        this->getContext()->_garbageCollector.push(fge::vulkan::GarbageBuffer(
-                this->g_uniformBuffer, this->g_uniformBufferAllocation, this->getContext()->getAllocator()));
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_uniformBufferAllocation);
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
+                this->g_uniformBuffer, this->g_uniformBufferAllocation, this->getContext().getAllocator()));
 
         this->g_uniformBuffer = VK_NULL_HANDLE;
         this->g_uniformBufferAllocation = VK_NULL_HANDLE;

--- a/sources/vulkan/C_vertexBuffer.cpp
+++ b/sources/vulkan/C_vertexBuffer.cpp
@@ -24,7 +24,8 @@
 namespace fge::vulkan
 {
 
-VertexBuffer::VertexBuffer() :
+VertexBuffer::VertexBuffer(Context const& context) :
+        ContextAware(context),
         g_buffer(VK_NULL_HANDLE),
         g_stagingBuffer(VK_NULL_HANDLE),
         g_bufferAllocation(VK_NULL_HANDLE),
@@ -35,11 +36,10 @@ VertexBuffer::VertexBuffer() :
 
         g_type(BufferTypes::UNINITIALIZED),
 
-        g_primitiveTopology(FGE_VULKAN_VERTEX_DEFAULT_TOPOLOGY),
-
-        g_context(nullptr)
+        g_primitiveTopology(FGE_VULKAN_VERTEX_DEFAULT_TOPOLOGY)
 {}
 VertexBuffer::VertexBuffer(const VertexBuffer& r) :
+        ContextAware(r),
         g_vertices(r.g_vertices),
 
         g_buffer(VK_NULL_HANDLE),
@@ -52,11 +52,10 @@ VertexBuffer::VertexBuffer(const VertexBuffer& r) :
 
         g_type(r.g_type),
 
-        g_primitiveTopology(r.g_primitiveTopology),
-
-        g_context(r.g_context)
+        g_primitiveTopology(r.g_primitiveTopology)
 {}
 VertexBuffer::VertexBuffer(VertexBuffer&& r) noexcept :
+        ContextAware(static_cast<ContextAware&&>(r)),
         g_vertices(std::move(r.g_vertices)),
 
         g_buffer(r.g_buffer),
@@ -69,9 +68,7 @@ VertexBuffer::VertexBuffer(VertexBuffer&& r) noexcept :
 
         g_type(r.g_type),
 
-        g_primitiveTopology(r.g_primitiveTopology),
-
-        g_context(r.g_context)
+        g_primitiveTopology(r.g_primitiveTopology)
 {
     r.g_buffer = VK_NULL_HANDLE;
     r.g_stagingBuffer = VK_NULL_HANDLE;
@@ -84,8 +81,6 @@ VertexBuffer::VertexBuffer(VertexBuffer&& r) noexcept :
     r.g_type = BufferTypes::UNINITIALIZED;
 
     r.g_primitiveTopology = FGE_VULKAN_VERTEX_DEFAULT_TOPOLOGY;
-
-    r.g_context = nullptr;
 }
 VertexBuffer::~VertexBuffer()
 {
@@ -94,7 +89,9 @@ VertexBuffer::~VertexBuffer()
 
 VertexBuffer& VertexBuffer::operator=(const VertexBuffer& r)
 {
-    if (this->g_type != r.g_type || this->g_context != r.g_context)
+    this->verifyContext(r);
+
+    if (this->g_type != r.g_type)
     {
         this->destroy();
     }
@@ -107,12 +104,11 @@ VertexBuffer& VertexBuffer::operator=(const VertexBuffer& r)
 
     this->g_primitiveTopology = r.g_primitiveTopology;
 
-    this->g_context = r.g_context;
-
     return *this;
 }
 VertexBuffer& VertexBuffer::operator=(VertexBuffer&& r) noexcept
 {
+    this->verifyContext(r);
     this->destroy();
 
     this->g_vertices = std::move(r.g_vertices);
@@ -129,8 +125,6 @@ VertexBuffer& VertexBuffer::operator=(VertexBuffer&& r) noexcept
 
     this->g_primitiveTopology = r.g_primitiveTopology;
 
-    this->g_context = r.g_context;
-
     r.g_buffer = VK_NULL_HANDLE;
     r.g_stagingBuffer = VK_NULL_HANDLE;
     r.g_bufferAllocation = VK_NULL_HANDLE;
@@ -143,15 +137,10 @@ VertexBuffer& VertexBuffer::operator=(VertexBuffer&& r) noexcept
 
     r.g_primitiveTopology = FGE_VULKAN_VERTEX_DEFAULT_TOPOLOGY;
 
-    r.g_context = nullptr;
-
     return *this;
 }
 
-void VertexBuffer::create(const Context& context,
-                          std::size_t vertexSize,
-                          VkPrimitiveTopology topology,
-                          BufferTypes type)
+void VertexBuffer::create(std::size_t vertexSize, VkPrimitiveTopology topology, BufferTypes type)
 {
     this->g_primitiveTopology = topology;
 
@@ -161,11 +150,10 @@ void VertexBuffer::create(const Context& context,
         return;
     }
 
-    if (type != this->g_type || (this->g_context != nullptr && &context != this->g_context))
+    if (type != this->g_type)
     {
         this->destroy();
         this->g_type = type;
-        this->g_context = &context;
     }
 
     this->resize(vertexSize);
@@ -216,8 +204,6 @@ void VertexBuffer::destroy()
         this->g_type = BufferTypes::UNINITIALIZED;
 
         this->g_primitiveTopology = FGE_VULKAN_VERTEX_DEFAULT_TOPOLOGY;
-
-        this->g_context = nullptr;
     }
 }
 
@@ -275,10 +261,6 @@ VkBuffer VertexBuffer::getVerticesBuffer() const
 VmaAllocation VertexBuffer::getVerticesBufferAllocation() const
 {
     return this->g_bufferAllocation;
-}
-const Context* VertexBuffer::getContext() const
-{
-    return this->g_context;
 }
 
 BufferTypes VertexBuffer::getType() const
@@ -348,16 +330,16 @@ void VertexBuffer::mapBuffer() const
     switch (this->g_type)
     {
     case BufferTypes::LOCAL:
-        vmaMapMemory(this->g_context->getAllocator(), this->g_bufferAllocation, &data);
+        vmaMapMemory(this->getContext().getAllocator(), this->g_bufferAllocation, &data);
         memcpy(data, this->g_vertices.data(), size);
-        vmaUnmapMemory(this->g_context->getAllocator(), this->g_bufferAllocation);
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_bufferAllocation);
         break;
     case BufferTypes::DEVICE:
-        vmaMapMemory(this->g_context->getAllocator(), this->g_stagingBufferAllocation, &data);
+        vmaMapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation, &data);
         memcpy(data, this->g_vertices.data(), size);
-        vmaUnmapMemory(this->g_context->getAllocator(), this->g_stagingBufferAllocation);
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation);
 
-        this->g_context->copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+        this->getContext().copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
         break;
     default:
         return;
@@ -369,15 +351,15 @@ void VertexBuffer::cleanBuffer() const
 #ifndef FGE_DEF_SERVER
     if (this->g_type != BufferTypes::UNINITIALIZED)
     {
-        this->g_context->_garbageCollector.push(
-                fge::vulkan::GarbageBuffer(this->g_buffer, this->g_bufferAllocation, this->g_context->getAllocator()));
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(this->g_buffer, this->g_bufferAllocation,
+                                                                             this->getContext().getAllocator()));
         this->g_buffer = VK_NULL_HANDLE;
         this->g_bufferAllocation = VK_NULL_HANDLE;
 
         if (this->g_type == BufferTypes::DEVICE)
         {
-            this->g_context->_garbageCollector.push(fge::vulkan::GarbageBuffer(
-                    this->g_stagingBuffer, this->g_stagingBufferAllocation, this->g_context->getAllocator()));
+            this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
+                    this->g_stagingBuffer, this->g_stagingBufferAllocation, this->getContext().getAllocator()));
 
             this->g_stagingBuffer = VK_NULL_HANDLE;
             this->g_stagingBufferAllocation = VK_NULL_HANDLE;
@@ -406,16 +388,16 @@ void VertexBuffer::updateBuffer() const
         switch (this->g_type)
         {
         case BufferTypes::LOCAL:
-            CreateBuffer(*this->g_context, bufferSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+            CreateBuffer(this->getContext(), bufferSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, this->g_buffer,
                          this->g_bufferAllocation);
             break;
         case BufferTypes::DEVICE:
-            CreateBuffer(*this->g_context, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+            CreateBuffer(this->getContext(), bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
                          this->g_stagingBuffer, this->g_stagingBufferAllocation);
 
-            CreateBuffer(*this->g_context, bufferSize,
+            CreateBuffer(this->getContext(), bufferSize,
                          VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_buffer, this->g_bufferAllocation);
             break;
@@ -432,7 +414,8 @@ void VertexBuffer::updateBuffer() const
 
 //IndexBuffer
 
-IndexBuffer::IndexBuffer() :
+IndexBuffer::IndexBuffer(Context const& context) :
+        ContextAware(context),
         g_buffer(VK_NULL_HANDLE),
         g_stagingBuffer(VK_NULL_HANDLE),
         g_bufferAllocation(VK_NULL_HANDLE),
@@ -441,11 +424,10 @@ IndexBuffer::IndexBuffer() :
 
         g_needUpdate(true),
 
-        g_type(BufferTypes::UNINITIALIZED),
-
-        g_context(nullptr)
+        g_type(BufferTypes::UNINITIALIZED)
 {}
 IndexBuffer::IndexBuffer(const IndexBuffer& r) :
+        ContextAware(r),
         g_indices(r.g_indices),
 
         g_buffer(VK_NULL_HANDLE),
@@ -456,11 +438,10 @@ IndexBuffer::IndexBuffer(const IndexBuffer& r) :
 
         g_needUpdate(true),
 
-        g_type(r.g_type),
-
-        g_context(r.g_context)
+        g_type(r.g_type)
 {}
 IndexBuffer::IndexBuffer(IndexBuffer&& r) noexcept :
+        ContextAware(static_cast<ContextAware&&>(r)),
         g_indices(std::move(r.g_indices)),
 
         g_buffer(r.g_buffer),
@@ -471,9 +452,7 @@ IndexBuffer::IndexBuffer(IndexBuffer&& r) noexcept :
 
         g_needUpdate(r.g_needUpdate),
 
-        g_type(r.g_type),
-
-        g_context(r.g_context)
+        g_type(r.g_type)
 {
     r.g_buffer = VK_NULL_HANDLE;
     r.g_stagingBuffer = VK_NULL_HANDLE;
@@ -484,8 +463,6 @@ IndexBuffer::IndexBuffer(IndexBuffer&& r) noexcept :
     r.g_needUpdate = true;
 
     r.g_type = BufferTypes::UNINITIALIZED;
-
-    r.g_context = nullptr;
 }
 IndexBuffer::~IndexBuffer()
 {
@@ -494,7 +471,9 @@ IndexBuffer::~IndexBuffer()
 
 IndexBuffer& IndexBuffer::operator=(const IndexBuffer& r)
 {
-    if (this->g_type != r.g_type || this->g_context != r.g_context)
+    this->verifyContext(r);
+
+    if (this->g_type != r.g_type)
     {
         this->destroy();
     }
@@ -505,12 +484,11 @@ IndexBuffer& IndexBuffer::operator=(const IndexBuffer& r)
 
     this->g_type = r.g_type;
 
-    this->g_context = r.g_context;
-
     return *this;
 }
 IndexBuffer& IndexBuffer::operator=(IndexBuffer&& r) noexcept
 {
+    this->verifyContext(r);
     this->destroy();
 
     this->g_indices = std::move(r.g_indices);
@@ -525,8 +503,6 @@ IndexBuffer& IndexBuffer::operator=(IndexBuffer&& r) noexcept
 
     this->g_type = r.g_type;
 
-    this->g_context = r.g_context;
-
     r.g_buffer = VK_NULL_HANDLE;
     r.g_stagingBuffer = VK_NULL_HANDLE;
     r.g_bufferAllocation = VK_NULL_HANDLE;
@@ -537,12 +513,10 @@ IndexBuffer& IndexBuffer::operator=(IndexBuffer&& r) noexcept
 
     r.g_type = BufferTypes::UNINITIALIZED;
 
-    r.g_context = nullptr;
-
     return *this;
 }
 
-void IndexBuffer::create(const Context& context, std::size_t indexSize, BufferTypes type)
+void IndexBuffer::create(std::size_t indexSize, BufferTypes type)
 {
     if (type == BufferTypes::UNINITIALIZED)
     {
@@ -550,11 +524,10 @@ void IndexBuffer::create(const Context& context, std::size_t indexSize, BufferTy
         return;
     }
 
-    if (type != this->g_type || (this->g_context != nullptr && &context != this->g_context))
+    if (type != this->g_type)
     {
         this->destroy();
         this->g_type = type;
-        this->g_context = &context;
     }
 
     this->resize(indexSize);
@@ -596,8 +569,6 @@ void IndexBuffer::destroy()
         this->g_needUpdate = true;
 
         this->g_type = BufferTypes::UNINITIALIZED;
-
-        this->g_context = nullptr;
     }
 }
 
@@ -645,10 +616,6 @@ VmaAllocation IndexBuffer::getIndicesBufferAllocation() const
 {
     return this->g_bufferAllocation;
 }
-const Context* IndexBuffer::getContext() const
-{
-    return this->g_context;
-}
 
 BufferTypes IndexBuffer::getType() const
 {
@@ -676,16 +643,16 @@ void IndexBuffer::mapBuffer() const
     switch (this->g_type)
     {
     case BufferTypes::LOCAL:
-        vmaMapMemory(this->g_context->getAllocator(), this->g_bufferAllocation, &data);
+        vmaMapMemory(this->getContext().getAllocator(), this->g_bufferAllocation, &data);
         memcpy(data, this->g_indices.data(), size);
-        vmaUnmapMemory(this->g_context->getAllocator(), this->g_bufferAllocation);
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_bufferAllocation);
         break;
     case BufferTypes::DEVICE:
-        vmaMapMemory(this->g_context->getAllocator(), this->g_stagingBufferAllocation, &data);
+        vmaMapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation, &data);
         memcpy(data, this->g_indices.data(), size);
-        vmaUnmapMemory(this->g_context->getAllocator(), this->g_stagingBufferAllocation);
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation);
 
-        this->g_context->copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+        this->getContext().copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
         break;
     default:
         return;
@@ -695,15 +662,15 @@ void IndexBuffer::cleanBuffer() const
 {
     if (this->g_type != BufferTypes::UNINITIALIZED)
     {
-        this->g_context->_garbageCollector.push(
-                fge::vulkan::GarbageBuffer(this->g_buffer, this->g_bufferAllocation, this->g_context->getAllocator()));
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(this->g_buffer, this->g_bufferAllocation,
+                                                                             this->getContext().getAllocator()));
         this->g_buffer = VK_NULL_HANDLE;
         this->g_bufferAllocation = VK_NULL_HANDLE;
 
         if (this->g_type == BufferTypes::DEVICE)
         {
-            this->g_context->_garbageCollector.push(fge::vulkan::GarbageBuffer(
-                    this->g_stagingBuffer, this->g_stagingBufferAllocation, this->g_context->getAllocator()));
+            this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
+                    this->g_stagingBuffer, this->g_stagingBufferAllocation, this->getContext().getAllocator()));
 
             this->g_stagingBuffer = VK_NULL_HANDLE;
             this->g_stagingBufferAllocation = VK_NULL_HANDLE;
@@ -730,16 +697,16 @@ void IndexBuffer::updateBuffer() const
         switch (this->g_type)
         {
         case BufferTypes::LOCAL:
-            CreateBuffer(*this->g_context, bufferSize, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+            CreateBuffer(this->getContext(), bufferSize, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, this->g_buffer,
                          this->g_bufferAllocation);
             break;
         case BufferTypes::DEVICE:
-            CreateBuffer(*this->g_context, bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+            CreateBuffer(this->getContext(), bufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
                          this->g_stagingBuffer, this->g_stagingBufferAllocation);
 
-            CreateBuffer(*this->g_context, bufferSize,
+            CreateBuffer(this->getContext(), bufferSize,
                          VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_buffer, this->g_bufferAllocation);
             break;

--- a/sources/vulkan/C_vertexBuffer.cpp
+++ b/sources/vulkan/C_vertexBuffer.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "FastEngine/vulkan/C_vertexBuffer.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/C_logicalDevice.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include <cstring>
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -402,7 +402,7 @@ void VertexBuffer::updateBuffer() const
                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_buffer, this->g_bufferAllocation);
             break;
         default:
-            throw std::runtime_error("unexpected code path !");
+            throw fge::Exception("unexpected code path !");
         }
 
         this->g_needUpdate = true;
@@ -711,7 +711,7 @@ void IndexBuffer::updateBuffer() const
                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, this->g_buffer, this->g_bufferAllocation);
             break;
         default:
-            throw std::runtime_error("unexpected code path !");
+            throw fge::Exception("unexpected code path !");
         }
 
         this->g_needUpdate = true;

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
+#include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/C_logicalDevice.hpp"
 #include "FastEngine/vulkan/C_physicalDevice.hpp"
 #include <cstring>
-#include <stdexcept>
 
 namespace fge::vulkan
 {
@@ -45,7 +45,7 @@ Context& GetActiveContext()
 #ifdef FGE_DEF_DEBUG
     if (gActiveContext == nullptr)
     {
-        throw std::runtime_error("No active context !");
+        throw fge::Exception("No active context !");
     }
 #endif
 
@@ -103,7 +103,7 @@ void CreateBuffer(const Context& context,
 
     if (result != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create buffer!");
+        throw fge::Exception("failed to create buffer!");
     }
 }
 
@@ -147,7 +147,7 @@ void CreateImage(const Context& context,
 
     if (result != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create image!");
+        throw fge::Exception("failed to create image!");
     }
 }
 
@@ -167,7 +167,7 @@ VkImageView CreateImageView(const LogicalDevice& logicalDevice, VkImage image, V
     VkImageView imageView = VK_NULL_HANDLE;
     if (vkCreateImageView(logicalDevice.getDevice(), &viewInfo, nullptr, &imageView) != VK_SUCCESS)
     {
-        throw std::runtime_error("failed to create texture image view!");
+        throw fge::Exception("failed to create texture image view!");
     }
 
     return imageView;

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -33,7 +33,28 @@ std::vector<const char*> ValidationLayers = {};
 std::vector<const char*> DeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
                                              VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME};
 
-Context* GlobalContext{nullptr};
+namespace
+{
+
+Context* gActiveContext{nullptr};
+
+} // namespace
+
+Context& GetActiveContext()
+{
+#ifdef FGE_DEF_DEBUG
+    if (gActiveContext == nullptr)
+    {
+        throw std::runtime_error("No active context !");
+    }
+#endif
+
+    return *gActiveContext;
+}
+void SetActiveContext(Context& context)
+{
+    gActiveContext = &context;
+}
 
 bool CheckValidationLayerSupport(const char* layerName)
 {

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -42,7 +42,7 @@ Context* gActiveContext{nullptr};
 
 Context& GetActiveContext()
 {
-#ifdef FGE_DEF_DEBUG
+#if defined(FGE_DEF_DEBUG) && !defined(FGE_DEF_SERVER)
     if (gActiveContext == nullptr)
     {
         throw fge::Exception("No active context !");


### PR DESCRIPTION
- Add a ContextAware base class for objects that require a Context in order to exist.
This is here in order to generalize the aspect of a Context aware object and implement "strict" rules about them.

- Remove GlobalContext and replace it with GetActiveContext() and SetActiveContext().
This remove the ugly usage of a global variable and the poor name choice.

- Use a fge::Exception instead of std ones.

- Context: add documentation, add retrieveExtensions static method.

- Context: rename g_commandPool to g_graphicsCommandPool.
As this reflect the link with the graphics queue.

- Context: add getGraphicsCommandPool() and allocateGraphicsCommandBuffers() methods
- This also mean that all RenderTarget objects doesn't have anymore a CommandPool.

- GarbageCollector: add the GarbageCommandBuffer

- replace extraCommandBuffers with executableGraphicsCommandBuffers directly into the Context instead of the RenderTarget.
Now RenderTexture is easier to use and we avoid command buffers overhead.

- Add a reusable command buffer for every transfer related actions like copying buffers.
This avoid the use of VkWaitIdle and accelerate things like staging/host buffer transfers.

