### PR TITLE
ObjText performance pass, UBO

### DIFF
--- a/includes/FastEngine/graphic/C_renderStates.hpp
+++ b/includes/FastEngine/graphic/C_renderStates.hpp
@@ -97,16 +97,19 @@ public:
 
     constexpr void setDynamicDescriptors(fge::vulkan::DescriptorSet const* dynamicDescriptors,
                                          uint32_t const* dynamicBufferSizes,
+                                         uint32_t const* dynamicBufferOffsets,
                                          uint32_t const* dynamicSets,
                                          uint32_t count)
     {
         this->g_dynamicDescriptors = dynamicDescriptors;
         this->g_dynamicBufferSizes = dynamicBufferSizes;
+        this->g_dynamicBufferOffsets = dynamicBufferOffsets;
         this->g_dynamicSets = dynamicSets;
         this->g_dynamicCount = count;
 
         assert(count == 0 || dynamicDescriptors != nullptr);
         assert(count == 0 || dynamicBufferSizes != nullptr);
+        assert(count == 0 || dynamicBufferOffsets != nullptr);
         assert(count == 0 || dynamicSets != nullptr);
     }
 
@@ -131,6 +134,12 @@ public:
         return this->g_dynamicBufferSizes[index];
     }
 
+    [[nodiscard]] constexpr uint32_t const* getDynamicBufferOffsets() const { return this->g_dynamicBufferOffsets; }
+    [[nodiscard]] constexpr uint32_t getDynamicBufferOffsets(uint32_t index) const
+    {
+        return this->g_dynamicBufferOffsets[index];
+    }
+
     [[nodiscard]] constexpr uint32_t const* getDynamicSets() const { return this->g_dynamicSets; }
     [[nodiscard]] constexpr uint32_t getDynamicSets(uint32_t index) const { return this->g_dynamicSets[index]; }
 
@@ -146,6 +155,7 @@ private:
     fge::vulkan::DescriptorSet const* g_dynamicDescriptors{nullptr};
     uint32_t g_dynamicCount{0};
     uint32_t const* g_dynamicBufferSizes{nullptr};
+    uint32_t const* g_dynamicBufferOffsets{nullptr};
     uint32_t const* g_dynamicSets{nullptr};
 
     uint32_t g_vertexCount{0};

--- a/includes/FastEngine/object/C_objShape.hpp
+++ b/includes/FastEngine/object/C_objShape.hpp
@@ -93,6 +93,7 @@ private:
     void updateTexCoords();
     void updateOutline();
     void resizeBuffer(std::size_t size) const;
+    void updateDescriptors() const;
 
     inline InstanceData* retrieveInstance(std::size_t index) const;
 
@@ -105,7 +106,6 @@ private:
     fge::vulkan::VertexBuffer g_outlineVertices;
 
     mutable std::size_t g_instancesCount;
-    mutable std::size_t g_instancesCapacity;
     mutable fge::vulkan::UniformBuffer g_instances;
     mutable fge::vulkan::DescriptorSet g_descriptorSet;
 

--- a/includes/FastEngine/object/C_objSpriteBatches.hpp
+++ b/includes/FastEngine/object/C_objSpriteBatches.hpp
@@ -113,7 +113,6 @@ private:
     std::vector<fge::Texture> g_textures;
 
     std::vector<InstanceData> g_instancesData;
-    mutable std::size_t g_instancesBufferCapacity;
     mutable fge::vulkan::UniformBuffer g_instancesTransform;
     mutable fge::vulkan::UniformBuffer g_instancesIndirectCommands;
     mutable fge::vulkan::DescriptorSet g_descriptorSets[2];

--- a/includes/FastEngine/object/C_objText.hpp
+++ b/includes/FastEngine/object/C_objText.hpp
@@ -33,12 +33,15 @@
 
 #define FGE_OBJTEXT_CLASSNAME "FGE:OBJ:TEXT"
 
+#define FGE_OBJTEXT_PIPELINE_CACHE_NAME FGE_OBJTEXT_CLASSNAME
+#define FGE_OBJTEXT_ID 0
+
 namespace fge
 {
 
 class ObjText;
 
-class FGE_API Character : public fge::Transformable, public fge::Drawable
+class FGE_API Character : public fge::Transformable
 {
 public:
     Character();
@@ -57,8 +60,7 @@ public:
                       fge::Vector2i const& textureSize,
                       float italicShear);
 
-    void draw(fge::RenderTarget& target, fge::RenderStates const& states) const override;
-    void drawVertices(bool outlineVertices, fge::RenderTarget& target, fge::RenderStates const& states) const;
+    void draw(fge::Transform& externalTransform, fge::RenderTarget& target, fge::RenderStates const& states) const;
 
     void setFillColor(fge::Color const& color);
     void setOutlineColor(fge::Color const& color);
@@ -169,6 +171,8 @@ private:
     fge::Color g_outlineColor{0, 0, 0};                 /// Text outline color
     float g_outlineThickness{0.0f};                     /// Thickness of the text's outline
 
+    mutable fge::vulkan::UniformBuffer g_charactersTransforms{fge::vulkan::GetActiveContext()};
+    mutable fge::vulkan::DescriptorSet g_charactersTransformsDescriptorSet;
     mutable std::vector<Character> g_characters;
     mutable fge::RectFloat g_bounds;                    /// Bounding rectangle of the text (in local coordinates)
     mutable bool g_geometryNeedUpdate{false};           /// Does the geometry need to be recomputed?

--- a/includes/FastEngine/object/C_objText.hpp
+++ b/includes/FastEngine/object/C_objText.hpp
@@ -160,6 +160,7 @@ public:
 
 private:
     void ensureGeometryUpdate() const;
+    void updateDescriptors() const;
 
     tiny_utf8::string g_string;                         /// String to display
     fge::Font g_font;                                   /// Font used to display the string

--- a/includes/FastEngine/vulkan/C_uniformBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_uniformBuffer.hpp
@@ -39,7 +39,7 @@ public:
         INDIRECT_BUFFER
     };
 
-    explicit UniformBuffer(Context const& context);
+    explicit UniformBuffer(Context const& context, Types type = Types::UNIFORM_BUFFER);
     UniformBuffer(UniformBuffer const& r);
     UniformBuffer(UniformBuffer&& r) noexcept;
     ~UniformBuffer() override;
@@ -48,22 +48,28 @@ public:
     UniformBuffer& operator=(UniformBuffer&& r) noexcept;
 
     void create(VkDeviceSize bufferSize, Types type = Types::UNIFORM_BUFFER);
+    void resize(VkDeviceSize bufferSize, bool shrink = false);
+    void shrinkToFit();
     void destroy() final;
 
     [[nodiscard]] VkBuffer getBuffer() const;
     [[nodiscard]] VmaAllocation getBufferAllocation() const;
     [[nodiscard]] void* getBufferMapped() const;
     [[nodiscard]] VkDeviceSize getBufferSize() const;
+    [[nodiscard]] VkDeviceSize getBufferCapacity() const;
     [[nodiscard]] Types getType() const;
 
     void copyData(void const* data, std::size_t size) const;
 
 private:
 #ifndef FGE_DEF_SERVER
+    void createBuffer(VkDeviceSize bufferSize, VkBuffer& buffer, VmaAllocation& bufferAllocation);
+
     VkBuffer g_uniformBuffer;
     VmaAllocation g_uniformBufferAllocation;
     void* g_uniformBufferMapped;
     VkDeviceSize g_bufferSize;
+    VkDeviceSize g_bufferCapacity;
 #else
     mutable std::vector<uint8_t> g_uniformBuffer;
 #endif

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -331,7 +331,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
         //Binding dynamic descriptors
         for (uint32_t i = 0; i < states._resInstances.getDynamicCount(); ++i)
         {
-            uint32_t const dynamicOffset = states._resInstances.getDynamicBufferSizes(i) * iInstance;
+            uint32_t const dynamicOffset = states._resInstances.getDynamicBufferSizes(i) * iInstance +
+                                           states._resInstances.getDynamicBufferOffsets(i);
             auto descriptorSet = states._resInstances.getDynamicDescriptors(i)->get();
             graphicPipeline->bindDynamicDescriptorSets(commandBuffer, &descriptorSet, 1, 1, &dynamicOffset,
                                                        states._resInstances.getDynamicSets(i));

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -399,15 +399,16 @@ FGE_OBJ_DRAW_BODY(ObjText)
             {
                 auto& character = this->g_characters[i];
 
+                fge::TransformUboData* transformData =
+                        reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
+                transformData->_modelTransform =
+                        copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
+                transformData->_viewTransform = target.getView().getTransform();
+
                 if (!character.g_visibility)
                 {
                     continue;
                 }
-
-                fge::TransformUboData* transformData =
-                        reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
-                transformData->_modelTransform = this->getTransform() * character.getTransform();
-                transformData->_viewTransform = target.getView().getTransform();
 
                 uint32_t dynamicBufferSize = fge::TransformUboData::uboSize;
                 uint32_t dynamicBufferOffsets = fge::TransformUboData::uboSize * i;
@@ -434,7 +435,8 @@ FGE_OBJ_DRAW_BODY(ObjText)
             {
                 fge::TransformUboData* transformData =
                         reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
-                transformData->_modelTransform = this->getTransform() * character.getTransform();
+                transformData->_modelTransform =
+                        copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
                 transformData->_viewTransform = target.getView().getTransform();
             }
 

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -18,9 +18,36 @@
 #include "FastEngine/arbitraryJsonTypes.hpp"
 #include "FastEngine/graphic/C_ftFont.hpp"
 #include "FastEngine/manager/font_manager.hpp"
+#include "FastEngine/manager/shader_manager.hpp"
 
 namespace fge
 {
+
+namespace
+{
+
+#ifndef FGE_DEF_SERVER
+void DefaultGraphicPipelineTextWithTexture_constructor(fge::vulkan::Context const& context,
+                                                       fge::RenderTarget::GraphicPipelineKey const& key,
+                                                       fge::vulkan::GraphicPipeline* graphicPipeline)
+{
+    graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_FRAGMENT)->_shader);
+    graphicPipeline->setShader(fge::shader::GetShader(FGE_SHADER_DEFAULT_VERTEX)->_shader);
+    graphicPipeline->setBlendMode(key._blendMode);
+    graphicPipeline->setPrimitiveTopology(key._topology);
+
+    auto& layout = context.getCacheLayout(FGE_OBJTEXT_CLASSNAME);
+    if (layout.getLayout() == VK_NULL_HANDLE)
+    {
+        layout.create({fge::vulkan::CreateSimpleLayoutBinding(
+                FGE_VULKAN_TRANSFORM_BINDING, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_SHADER_STAGE_VERTEX_BIT)});
+    }
+
+    graphicPipeline->setDescriptorSetLayouts({layout.getLayout(), context.getTextureLayout().getLayout()});
+}
+#endif // FGE_DEF_SERVER
+
+} //end namespace
 
 Character::Character() :
         g_vertices(fge::vulkan::GetActiveContext()),
@@ -102,36 +129,19 @@ void Character::addGlyphQuad(bool outlineVertices,
     vertices->append(fge::vulkan::Vertex{{size.x + right - italicShear * bottom, size.y + bottom}, color, {u2, v2}});
 }
 
-void Character::draw(fge::RenderTarget& target, fge::RenderStates const& states) const
+void Character::draw(fge::Transform& externalTransform,
+                     fge::RenderTarget& target,
+                     fge::RenderStates const& states) const
 {
     if (this->g_visibility)
     {
-        auto copyStates = states.copy(this->_transform.start(*this, states._resTransform.get()));
+        auto copyStates = states.copy(externalTransform.start(*this, states._resTransform.get()));
         copyStates._resTextures = states._resTextures;
 
         copyStates._vertexBuffer = &this->g_outlineVertices;
         target.draw(copyStates);
         copyStates._vertexBuffer = &this->g_vertices;
         target.draw(copyStates);
-    }
-}
-void Character::drawVertices(bool outlineVertices, fge::RenderTarget& target, fge::RenderStates const& states) const
-{
-    if (this->g_visibility)
-    {
-        auto copyStates = states.copy(this->_transform.start(*this, states._resTransform.get()));
-        copyStates._resTextures = states._resTextures;
-
-        if (outlineVertices)
-        {
-            copyStates._vertexBuffer = &this->g_outlineVertices;
-            target.draw(copyStates);
-        }
-        else
-        {
-            copyStates._vertexBuffer = &this->g_vertices;
-            target.draw(copyStates);
-        }
     }
 }
 
@@ -370,17 +380,73 @@ FGE_OBJ_DRAW_BODY(ObjText)
 
         copyStates._resTextures.set(&this->g_font.getData()->_font->getTexture(this->g_characterSize), 1);
 
+        fge::RenderTarget::GraphicPipelineKey const graphicPipelineKey{VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+                                                                       copyStates._blendMode, FGE_OBJTEXT_ID};
+
+        auto* graphicPipeline = target.getGraphicPipeline(FGE_OBJTEXT_PIPELINE_CACHE_NAME, graphicPipelineKey,
+                                                          DefaultGraphicPipelineTextWithTexture_constructor);
+
+        auto characterStates = copyStates.copy(nullptr);
+        characterStates._resTextures = copyStates._resTextures;
+
+        bool transformDataUpdated = false;
+
         if (this->g_outlineThickness != 0.0f)
         {
-            for (auto const& character: this->g_characters)
+            transformDataUpdated = true;
+
+            for (std::size_t i = 0; i < this->g_characters.size(); ++i)
             {
-                character.drawVertices(true, target, copyStates);
+                auto& character = this->g_characters[i];
+
+                if (!character.g_visibility)
+                {
+                    continue;
+                }
+
+                fge::TransformUboData* transformData =
+                        reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
+                transformData->_modelTransform = this->getTransform() * character.getTransform();
+                transformData->_viewTransform = target.getView().getTransform();
+
+                uint32_t dynamicBufferSize = fge::TransformUboData::uboSize;
+                uint32_t dynamicBufferOffsets = fge::TransformUboData::uboSize * i;
+                uint32_t dynamicSet = FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TRANSFORM;
+                characterStates._resInstances.setDynamicDescriptors(&this->g_charactersTransformsDescriptorSet,
+                                                                    &dynamicBufferSize, &dynamicBufferOffsets,
+                                                                    &dynamicSet, 1);
+
+                characterStates._vertexBuffer = &character.g_outlineVertices;
+                target.draw(characterStates, graphicPipeline);
             }
         }
 
-        for (auto const& character: this->g_characters)
+        for (std::size_t i = 0; i < this->g_characters.size(); ++i)
         {
-            character.drawVertices(false, target, copyStates);
+            auto& character = this->g_characters[i];
+
+            if (!character.g_visibility)
+            {
+                continue;
+            }
+
+            if (!transformDataUpdated)
+            {
+                fge::TransformUboData* transformData =
+                        reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
+                transformData->_modelTransform = this->getTransform() * character.getTransform();
+                transformData->_viewTransform = target.getView().getTransform();
+            }
+
+            uint32_t dynamicBufferSize = fge::TransformUboData::uboSize;
+            uint32_t dynamicBufferOffsets = fge::TransformUboData::uboSize * i;
+            uint32_t dynamicSet = FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TRANSFORM;
+            characterStates._resInstances.setDynamicDescriptors(&this->g_charactersTransformsDescriptorSet,
+                                                                &dynamicBufferSize, &dynamicBufferOffsets, &dynamicSet,
+                                                                1);
+
+            characterStates._vertexBuffer = &character.g_vertices;
+            target.draw(characterStates, graphicPipeline);
         }
     }
 }
@@ -687,6 +753,30 @@ void ObjText::ensureGeometryUpdate() const
         // Advance to the next character
         position.x += characterLength;
     }
+
+    //Updating UBO
+    auto const& context = fge::vulkan::GetActiveContext();
+
+    this->g_charactersTransforms.create(fge::TransformUboData::uboSize * usedCharacters);
+
+    if (this->g_charactersTransformsDescriptorSet.get() == VK_NULL_HANDLE)
+    {
+        auto& layout = context.getCacheLayout(FGE_OBJTEXT_CLASSNAME);
+        if (layout.getLayout() == VK_NULL_HANDLE)
+        {
+            layout.create({fge::vulkan::CreateSimpleLayoutBinding(FGE_VULKAN_TRANSFORM_BINDING,
+                                                                  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+                                                                  VK_SHADER_STAGE_VERTEX_BIT)});
+        }
+
+        this->g_charactersTransformsDescriptorSet =
+                context.getMultiUseDescriptorPool().allocateDescriptorSet(layout.getLayout()).value();
+    }
+
+    fge::vulkan::DescriptorSet::Descriptor descriptor{this->g_charactersTransforms, FGE_VULKAN_TRANSFORM_BINDING,
+                                                      fge::vulkan::DescriptorSet::Descriptor::BufferTypes::DYNAMIC,
+                                                      fge::TransformUboData::uboSize};
+    this->g_charactersTransformsDescriptorSet.updateDescriptorSet(&descriptor, 1);
 
     // Remove extra characters
     this->g_characters.resize(usedCharacters);

--- a/sources/vulkan/C_uniformBuffer.cpp
+++ b/sources/vulkan/C_uniformBuffer.cpp
@@ -22,17 +22,18 @@
 namespace fge::vulkan
 {
 
-UniformBuffer::UniformBuffer(Context const& context) :
+UniformBuffer::UniformBuffer(Context const& context, Types type) :
 #ifndef FGE_DEF_SERVER
         ContextAware(context),
         g_uniformBuffer(VK_NULL_HANDLE),
         g_uniformBufferAllocation(VK_NULL_HANDLE),
         g_uniformBufferMapped(nullptr),
         g_bufferSize(0),
-        g_type(Types::UNIFORM_BUFFER)
+        g_bufferCapacity(0),
+        g_type(type)
 #else
         ContextAware(context),
-        g_type(Types::UNIFORM_BUFFER)
+        g_type(type)
 #endif
 {}
 UniformBuffer::UniformBuffer(UniformBuffer const& r) :
@@ -48,6 +49,7 @@ UniformBuffer::UniformBuffer(UniformBuffer&& r) noexcept :
         g_uniformBufferAllocation(r.g_uniformBufferAllocation),
         g_uniformBufferMapped(r.g_uniformBufferMapped),
         g_bufferSize(r.g_bufferSize),
+        g_bufferCapacity(r.g_bufferCapacity),
         g_type(r.g_type)
 #else
         g_uniformBuffer(std::move(r.g_uniformBuffer)),
@@ -59,6 +61,7 @@ UniformBuffer::UniformBuffer(UniformBuffer&& r) noexcept :
     r.g_uniformBufferAllocation = VK_NULL_HANDLE;
     r.g_uniformBufferMapped = nullptr;
     r.g_bufferSize = 0;
+    r.g_bufferCapacity = 0;
 #endif
     r.g_type = Types::UNIFORM_BUFFER;
 }
@@ -83,11 +86,13 @@ UniformBuffer& UniformBuffer::operator=(UniformBuffer&& r) noexcept
     this->g_uniformBufferAllocation = r.g_uniformBufferAllocation;
     this->g_uniformBufferMapped = r.g_uniformBufferMapped;
     this->g_bufferSize = r.g_bufferSize;
+    this->g_bufferCapacity = r.g_bufferCapacity;
 
     r.g_uniformBuffer = VK_NULL_HANDLE;
     r.g_uniformBufferAllocation = VK_NULL_HANDLE;
     r.g_uniformBufferMapped = nullptr;
     r.g_bufferSize = 0;
+    r.g_bufferCapacity = 0;
 #else
     this->g_uniformBuffer = std::move(r.g_uniformBuffer);
 #endif
@@ -99,6 +104,7 @@ UniformBuffer& UniformBuffer::operator=(UniformBuffer&& r) noexcept
 void UniformBuffer::create(VkDeviceSize bufferSize, Types type)
 {
     this->g_type = type;
+
 #ifdef FGE_DEF_SERVER
     if (static_cast<std::size_t>(bufferSize) == 0)
     {
@@ -109,7 +115,7 @@ void UniformBuffer::create(VkDeviceSize bufferSize, Types type)
     this->destroy();
     this->g_uniformBuffer.resize(static_cast<std::size_t>(bufferSize));
 #else
-    if (static_cast<std::size_t>(bufferSize) == 0)
+    if (bufferSize == 0)
     {
         this->destroy();
         return;
@@ -117,29 +123,104 @@ void UniformBuffer::create(VkDeviceSize bufferSize, Types type)
 
     this->destroy();
 
-    VkBufferUsageFlags usageFlags = 0;
-    switch (type)
-    {
-    case Types::UNIFORM_BUFFER:
-        usageFlags = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-        break;
-    case Types::STORAGE_BUFFER:
-        usageFlags = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        break;
-    case Types::INDIRECT_BUFFER:
-        usageFlags = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-        break;
-    }
-
-    CreateBuffer(this->getContext(), bufferSize, usageFlags,
-                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, this->g_uniformBuffer,
-                 this->g_uniformBufferAllocation);
-
+    this->createBuffer(bufferSize, this->g_uniformBuffer, this->g_uniformBufferAllocation);
     this->g_bufferSize = bufferSize;
+    this->g_bufferCapacity = bufferSize;
 
     vmaMapMemory(this->getContext().getAllocator(), this->g_uniformBufferAllocation, &this->g_uniformBufferMapped);
 #endif
 }
+void UniformBuffer::resize(VkDeviceSize bufferSize, bool shrink)
+{
+#ifdef FGE_DEF_SERVER
+    this->g_uniformBuffer.resize(static_cast<std::size_t>(bufferSize));
+    if (shrink)
+    {
+        this->shrinkToFit();
+    }
+#else
+    if (bufferSize == 0)
+    {
+        this->g_bufferSize = 0;
+        if (shrink)
+        {
+            this->shrinkToFit();
+        }
+        return;
+    }
+
+    if (bufferSize <= this->g_bufferCapacity)
+    {
+        this->g_bufferSize = bufferSize;
+        if (shrink)
+        {
+            this->shrinkToFit();
+        }
+        return;
+    }
+
+    if (this->g_bufferCapacity == 0)
+    {
+        this->create(bufferSize, this->g_type);
+    }
+    else
+    {
+        VkBuffer newBuffer{VK_NULL_HANDLE};
+        VmaAllocation newBufferAllocation{VK_NULL_HANDLE};
+        void* newBufferMapped{nullptr};
+
+        this->createBuffer(bufferSize, newBuffer, newBufferAllocation);
+        vmaMapMemory(this->getContext().getAllocator(), newBufferAllocation, &newBufferMapped);
+
+        std::memcpy(newBufferMapped, this->g_uniformBufferMapped, static_cast<std::size_t>(this->g_bufferSize));
+
+        vmaUnmapMemory(this->getContext().getAllocator(), this->g_uniformBufferAllocation);
+        this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
+                this->g_uniformBuffer, this->g_uniformBufferAllocation, this->getContext().getAllocator()));
+
+        this->g_uniformBuffer = newBuffer;
+        this->g_uniformBufferAllocation = newBufferAllocation;
+        this->g_uniformBufferMapped = newBufferMapped;
+        this->g_bufferSize = bufferSize;
+        this->g_bufferCapacity = bufferSize;
+    }
+#endif
+}
+void UniformBuffer::shrinkToFit()
+{
+#ifdef FGE_DEF_SERVER
+    this->g_uniformBuffer.shrink_to_fit();
+#else
+    if (this->g_bufferSize == this->g_bufferCapacity)
+    {
+        return;
+    }
+    if (this->g_bufferSize == 0)
+    {
+        this->destroy();
+        return;
+    }
+
+    VkBuffer newBuffer{VK_NULL_HANDLE};
+    VmaAllocation newBufferAllocation{VK_NULL_HANDLE};
+    void* newBufferMapped{nullptr};
+
+    this->createBuffer(this->g_bufferSize, newBuffer, newBufferAllocation);
+    vmaMapMemory(this->getContext().getAllocator(), newBufferAllocation, &newBufferMapped);
+
+    std::memcpy(newBufferMapped, this->g_uniformBufferMapped, static_cast<std::size_t>(this->g_bufferSize));
+
+    vmaUnmapMemory(this->getContext().getAllocator(), this->g_uniformBufferAllocation);
+    this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
+            this->g_uniformBuffer, this->g_uniformBufferAllocation, this->getContext().getAllocator()));
+
+    this->g_uniformBuffer = newBuffer;
+    this->g_uniformBufferAllocation = newBufferAllocation;
+    this->g_uniformBufferMapped = newBufferMapped;
+    this->g_bufferCapacity = this->g_bufferSize;
+#endif
+}
+
 void UniformBuffer::destroy()
 {
 #ifdef FGE_DEF_SERVER
@@ -156,6 +237,7 @@ void UniformBuffer::destroy()
         this->g_uniformBufferAllocation = VK_NULL_HANDLE;
         this->g_uniformBufferMapped = nullptr;
         this->g_bufferSize = 0;
+        this->g_bufferCapacity = 0;
         this->g_type = Types::UNIFORM_BUFFER;
     }
 #endif
@@ -178,6 +260,37 @@ VkDeviceSize UniformBuffer::getBufferSize() const
 {
     return this->g_bufferSize;
 }
+VkDeviceSize UniformBuffer::getBufferCapacity() const
+{
+    return this->g_bufferCapacity;
+}
+
+void UniformBuffer::createBuffer(VkDeviceSize bufferSize, VkBuffer& buffer, VmaAllocation& bufferAllocation)
+{
+    if (bufferSize == 0)
+    {
+        buffer = VK_NULL_HANDLE;
+        bufferAllocation = VK_NULL_HANDLE;
+        return;
+    }
+
+    VkBufferUsageFlags usageFlags = 0;
+    switch (this->g_type)
+    {
+    case Types::UNIFORM_BUFFER:
+        usageFlags = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+        break;
+    case Types::STORAGE_BUFFER:
+        usageFlags = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        break;
+    case Types::INDIRECT_BUFFER:
+        usageFlags = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+        break;
+    }
+
+    CreateBuffer(this->getContext(), bufferSize, usageFlags,
+                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, buffer, bufferAllocation);
+}
 #else
 VkBuffer UniformBuffer::getBuffer() const
 {
@@ -195,6 +308,10 @@ VkDeviceSize UniformBuffer::getBufferSize() const
 {
     return static_cast<VkDeviceSize>(this->g_uniformBuffer.size());
 }
+VkDeviceSize UniformBuffer::getBufferCapacity() const
+{
+    return static_cast<VkDeviceSize>(this->g_uniformBuffer.capacity());
+}
 #endif
 
 UniformBuffer::Types UniformBuffer::getType() const
@@ -204,9 +321,9 @@ UniformBuffer::Types UniformBuffer::getType() const
 
 void UniformBuffer::copyData(void const* data, std::size_t size) const
 {
-    if (data != nullptr && size > 0)
+    if (data != nullptr && size > 0 && size <= static_cast<std::size_t>(this->getBufferSize()))
     {
-        memcpy(this->getBufferMapped(), data, size);
+        std::memcpy(this->getBufferMapped(), data, size);
     }
 }
 


### PR DESCRIPTION
Use dynamic descriptors set for all Character transform : 
- This provide a FPS boost for drawing a lot of characters
- Performance when the application modify the text often
- Lost the drawable inheritance on characters

UniformBuffer :
- Add a capacity optimization with methods likes : resize(), shrinkToFit()
- Applying this change for ObjSpriteBatches, ObjShape and ObjText

