### PR TITLE
Map view change

### DIFF
--- a/examples/deepText_005/main.cpp
+++ b/examples/deepText_005/main.cpp
@@ -95,7 +95,7 @@ public:
 
         objSliderFreq->_onSlide.addLambda([&](float ratio) {
             math_f = std::clamp(3.0f * ratio, 0.1f, 3.0f);
-            frequencyText->setString(fge::string::ToStr(math_f) + "Hz");
+            frequencyText->setString(fge::string::ToStr(math_f, 2, false) + "Hz");
         });
 
         //Add a rectangle representing the bounds of the moving text

--- a/examples/lightAndObstacle_002/main.cpp
+++ b/examples/lightAndObstacle_002/main.cpp
@@ -93,7 +93,7 @@ public:
         auto* follow = scene->_properties["follow"].getPtr<std::string>();
         if (follow != nullptr && *follow == "obstacle" && !this->_tags.check("duplicate"))
         {
-            this->setPosition(screen.mapPixelToCoords(event.getMousePixelPos()));
+            this->setPosition(screen.mapFramebufferCoordsToViewSpace(event.getMousePixelPos()));
         }
     }
 
@@ -313,7 +313,7 @@ public:
             auto* follow = this->_properties["follow"].getPtr<std::string>();
             if (follow != nullptr && *follow == "light")
             {
-                light->getObject()->setPosition(renderWindow.mapPixelToCoords(event.getMousePixelPos()));
+                light->getObject()->setPosition(renderWindow.mapFramebufferCoordsToViewSpace(event.getMousePixelPos()));
             }
 
             //Drawing

--- a/examples/tileMapAndPathFinding_001/main.cpp
+++ b/examples/tileMapAndPathFinding_001/main.cpp
@@ -258,7 +258,8 @@ public:
         //Create event callback for mouse button pressed
         event._onMouseButtonDown.addLambda([&](fge::Event const&, SDL_MouseButtonEvent const& mouseButtonEvent) {
             //Get the mouse position
-            auto mousePosition = renderWindow.mapFramebufferCoordsToWorldSpace(fge::Vector2i{mouseButtonEvent.x, mouseButtonEvent.y});
+            auto mousePosition = renderWindow.mapFramebufferCoordsToWorldSpace(
+                    fge::Vector2i{mouseButtonEvent.x, mouseButtonEvent.y});
 
             //Set the pathfinder goal when the left mouse button is pressed
             if (mouseButtonEvent.button == SDL_BUTTON_LEFT)

--- a/examples/tileMapAndPathFinding_001/main.cpp
+++ b/examples/tileMapAndPathFinding_001/main.cpp
@@ -258,7 +258,7 @@ public:
         //Create event callback for mouse button pressed
         event._onMouseButtonDown.addLambda([&](fge::Event const&, SDL_MouseButtonEvent const& mouseButtonEvent) {
             //Get the mouse position
-            auto mousePosition = renderWindow.mapPixelToCoords(fge::Vector2i{mouseButtonEvent.x, mouseButtonEvent.y});
+            auto mousePosition = renderWindow.mapFramebufferCoordsToWorldSpace(fge::Vector2i{mouseButtonEvent.x, mouseButtonEvent.y});
 
             //Set the pathfinder goal when the left mouse button is pressed
             if (mouseButtonEvent.button == SDL_BUTTON_LEFT)

--- a/includes/FastEngine/C_callback.hpp
+++ b/includes/FastEngine/C_callback.hpp
@@ -197,7 +197,7 @@ public:
      * \brief Copy constructor that does nothing
      */
     CallbackHandler([[maybe_unused]] fge::CallbackHandler<Types...> const& n) :
-            fge::Subscription() {};
+            fge::Subscription(){};
     /**
      * \brief Move constructor prohibited
      */

--- a/includes/FastEngine/C_callback.hpp
+++ b/includes/FastEngine/C_callback.hpp
@@ -197,7 +197,7 @@ public:
      * \brief Copy constructor that does nothing
      */
     CallbackHandler([[maybe_unused]] fge::CallbackHandler<Types...> const& n) :
-            fge::Subscription(){};
+            fge::Subscription() {};
     /**
      * \brief Move constructor prohibited
      */

--- a/includes/FastEngine/C_subscription.hpp
+++ b/includes/FastEngine/C_subscription.hpp
@@ -52,7 +52,7 @@ public:
     Subscription() = default;
 
     ///\warning Empty copy constructor as it's not permitted (does nothing)
-    Subscription([[maybe_unused]] fge::Subscription const& r) {};
+    Subscription([[maybe_unused]] fge::Subscription const& r){};
     Subscription(fge::Subscription&& r) noexcept;
 
     /**
@@ -152,7 +152,7 @@ public:
     Subscriber() = default;
 
     ///\warning Empty copy constructor as it's not permitted (does nothing)
-    Subscriber([[maybe_unused]] fge::Subscriber const& n) {};
+    Subscriber([[maybe_unused]] fge::Subscriber const& n){};
     ///\warning Move constructor prohibited
     Subscriber(fge::Subscriber&& n) noexcept = delete;
 

--- a/includes/FastEngine/C_subscription.hpp
+++ b/includes/FastEngine/C_subscription.hpp
@@ -52,7 +52,7 @@ public:
     Subscription() = default;
 
     ///\warning Empty copy constructor as it's not permitted (does nothing)
-    Subscription([[maybe_unused]] fge::Subscription const& r){};
+    Subscription([[maybe_unused]] fge::Subscription const& r) {};
     Subscription(fge::Subscription&& r) noexcept;
 
     /**
@@ -152,7 +152,7 @@ public:
     Subscriber() = default;
 
     ///\warning Empty copy constructor as it's not permitted (does nothing)
-    Subscriber([[maybe_unused]] fge::Subscriber const& n){};
+    Subscriber([[maybe_unused]] fge::Subscriber const& n) {};
     ///\warning Move constructor prohibited
     Subscriber(fge::Subscriber&& n) noexcept = delete;
 

--- a/includes/FastEngine/C_vector.hpp
+++ b/includes/FastEngine/C_vector.hpp
@@ -19,6 +19,8 @@
 
 #include <cstdint>
 #define GLM_FORCE_CTOR_INIT
+#define GLM_FORCE_DEPTH_ZERO_TO_ONE
+#define GLM_FORCE_LEFT_HANDED
 #include "glm/glm.hpp"
 
 #define FGE_NUMERIC_LIMITS_VECTOR_MAX(_vecType) (_vecType{std::numeric_limits<_vecType::value_type>::max()})

--- a/includes/FastEngine/extra/extra_function.hpp
+++ b/includes/FastEngine/extra/extra_function.hpp
@@ -211,13 +211,6 @@ enum class ClipClampModes
                                          fge::ClipClampModes clampMode);
 
 ///Render
-[[nodiscard]] FGE_API fge::RectInt CoordToPixelRect(fge::RectFloat const& rect, fge::RenderTarget const& target);
-[[nodiscard]] FGE_API fge::RectInt
-CoordToPixelRect(fge::RectFloat const& rect, fge::RenderTarget const& target, fge::View const& view);
-[[nodiscard]] FGE_API fge::RectFloat PixelToCoordRect(fge::RectInt const& rect, fge::RenderTarget const& target);
-[[nodiscard]] FGE_API fge::RectFloat
-PixelToCoordRect(fge::RectInt const& rect, fge::RenderTarget const& target, fge::View const& view);
-
 [[nodiscard]] FGE_API fge::RectFloat GetScreenRect(fge::RenderTarget const& target);
 [[nodiscard]] FGE_API fge::RectFloat GetScreenRect(fge::RenderTarget const& target, fge::View const& view);
 

--- a/includes/FastEngine/extra/extra_function.hpp
+++ b/includes/FastEngine/extra/extra_function.hpp
@@ -182,6 +182,17 @@ GetNearestPoint(fge::Vector2f const& point, TIterator const& pointsBegin, TItera
 [[nodiscard]] inline constexpr float
 GetHandedness(fge::Vector2f const& vec1, fge::Vector2f const& vec2, fge::Vector2f const& vec3);
 
+//Convert a 'x' value ranging from xMin-Xmax to a 'y' value ranging from yMin-Ymax
+[[nodiscard]] inline constexpr float ConvertRange(float x, float xMin, float xMax, float yMin, float yMax);
+[[nodiscard]] inline constexpr fge::Vector2f ConvertRange(fge::Vector2f const& x,
+                                                          fge::Vector2f const& xMin,
+                                                          fge::Vector2f const& xMax,
+                                                          fge::Vector2f const& yMin,
+                                                          fge::Vector2f const& yMax);
+
+[[nodiscard]] inline constexpr fge::Vector2f MapCircleToSquareCoords(fge::Vector2f const& circleCoords);
+[[nodiscard]] inline constexpr fge::Vector2f MapSquareToCircleCoords(fge::Vector2f const& squareCoords);
+
 /*
 Implementation of Andrew's monotone chain 2D convex hull algorithm.
 Asymptotic complexity: O(n log n).

--- a/includes/FastEngine/extra/extra_function.inl
+++ b/includes/FastEngine/extra/extra_function.inl
@@ -16,7 +16,6 @@
 
 namespace fge
 {
-
 ///Utility
 char UnicodeToChar(uint32_t unicode)
 {
@@ -210,6 +209,41 @@ inline constexpr float GetHandedness(fge::Vector2f const& vec1, fge::Vector2f co
     auto const edge2 = vec3 - vec2;
 
     return fge::Cross2d(edge1, edge2);
+}
+
+inline constexpr float ConvertRange(float x, float xMin, float xMax, float yMin, float yMax)
+{
+    float const a = (yMax - yMin) / (xMax - xMin);
+    float const b = yMin - xMin * a;
+    return a * x + b;
+}
+inline constexpr fge::Vector2f ConvertRange(fge::Vector2f const& x,
+                                            fge::Vector2f const& xMin,
+                                            fge::Vector2f const& xMax,
+                                            fge::Vector2f const& yMin,
+                                            fge::Vector2f const& yMax)
+{
+    return fge::Vector2f{ConvertRange(x.x, xMin.x, xMax.x, yMin.x, yMax.x),
+                         ConvertRange(x.y, xMin.y, xMax.y, yMin.y, yMax.y)};
+}
+
+inline constexpr fge::Vector2f MapCircleToSquareCoords(fge::Vector2f const& circleCoords)
+{
+    fge::Vector2f const circleCoordsPow2 = circleCoords * circleCoords;
+
+    return fge::Vector2f{0.5f * std::sqrt(2.0f + circleCoordsPow2.x - circleCoordsPow2.y +
+                                          2.0f * circleCoords.x * static_cast<float>(M_SQRT2)) -
+                                 0.5f * std::sqrt(2.0f + circleCoordsPow2.x - circleCoordsPow2.y -
+                                                  2.0f * circleCoords.x * static_cast<float>(M_SQRT2)),
+                         0.5f * std::sqrt(2.0f - circleCoordsPow2.x + circleCoordsPow2.y +
+                                          2.0f * circleCoords.y * static_cast<float>(M_SQRT2)) -
+                                 0.5f * std::sqrt(2.0f - circleCoordsPow2.x + circleCoordsPow2.y -
+                                                  2.0f * circleCoords.y * static_cast<float>(M_SQRT2))};
+}
+inline constexpr fge::Vector2f MapSquareToCircleCoords(fge::Vector2f const& squareCoords)
+{
+    return fge::Vector2f{squareCoords.x * std::sqrt(1.0f - 0.5f * squareCoords.y * squareCoords.y),
+                         squareCoords.y * std::sqrt(1.0f - 0.5f * squareCoords.x * squareCoords.x)};
 }
 
 ///Color

--- a/includes/FastEngine/extra/extra_string.hpp
+++ b/includes/FastEngine/extra/extra_string.hpp
@@ -353,6 +353,7 @@ FGE_API std::string ToStr(unsigned long long int val);
  * \return The converted string
  */
 FGE_API std::string ToStr(float val);
+FGE_API std::string ToStr(float val, unsigned int precision, bool keepExtraZeros = false);
 /**
  * \ingroup extraString
  * \brief Convert efficiently a double to a string
@@ -361,6 +362,7 @@ FGE_API std::string ToStr(float val);
  * \return The converted string
  */
 FGE_API std::string ToStr(double val);
+FGE_API std::string ToStr(double val, unsigned int precision, bool keepExtraZeros = false);
 /**
  * \ingroup extraString
  * \brief Convert efficiently a long double to a string
@@ -369,6 +371,7 @@ FGE_API std::string ToStr(double val);
  * \return The converted string
  */
 FGE_API std::string ToStr(long double val);
+FGE_API std::string ToStr(long double val, unsigned int precision, bool keepExtraZeros = false);
 
 //Pointer
 /**

--- a/includes/FastEngine/graphic/C_renderTarget.hpp
+++ b/includes/FastEngine/graphic/C_renderTarget.hpp
@@ -107,10 +107,25 @@ public:
     [[nodiscard]] View const& getDefaultView() const;
     [[nodiscard]] fge::vulkan::Viewport getViewport(View const& view) const;
 
-    [[nodiscard]] Vector2f mapPixelToCoords(Vector2i const& point) const;
-    [[nodiscard]] Vector2f mapPixelToCoords(Vector2i const& point, View const& view) const;
-    [[nodiscard]] Vector2i mapCoordsToPixel(Vector2f const& point) const;
-    [[nodiscard]] Vector2i mapCoordsToPixel(Vector2f const& point, View const& view) const;
+    [[nodiscard]] Vector2f mapFramebufferCoordsToViewSpace(Vector2i const& point) const;
+    [[nodiscard]] Vector2f mapFramebufferCoordsToViewSpace(Vector2i const& point, View const& view) const;
+    [[nodiscard]] Vector2f mapFramebufferCoordsToWorldSpace(Vector2i const& point) const;
+    [[nodiscard]] Vector2f mapFramebufferCoordsToWorldSpace(Vector2i const& point, View const& view) const;
+
+    [[nodiscard]] Vector2i mapViewCoordsToFramebufferSpace(Vector2f const& point) const;
+    [[nodiscard]] Vector2i mapViewCoordsToFramebufferSpace(Vector2f const& point, View const& view) const;
+    [[nodiscard]] Vector2i mapWorldCoordsToFramebufferSpace(Vector2f const& point) const;
+    [[nodiscard]] Vector2i mapWorldCoordsToFramebufferSpace(Vector2f const& point, View const& view) const;
+
+    [[nodiscard]] RectFloat mapFramebufferRectToViewSpace(RectInt const& rect) const;
+    [[nodiscard]] RectFloat mapFramebufferRectToViewSpace(RectInt const& rect, View const& view) const;
+    [[nodiscard]] RectFloat mapFramebufferRectToWorldSpace(RectInt const& rect) const;
+    [[nodiscard]] RectFloat mapFramebufferRectToWorldSpace(RectInt const& rect, View const& view) const;
+
+    [[nodiscard]] RectInt mapViewRectToFramebufferSpace(RectFloat const& rect) const;
+    [[nodiscard]] RectInt mapViewRectToFramebufferSpace(RectFloat const& rect, View const& view) const;
+    [[nodiscard]] RectInt mapWorldRectToFramebufferSpace(RectFloat const& rect) const;
+    [[nodiscard]] RectInt mapWorldRectToFramebufferSpace(RectFloat const& rect, View const& view) const;
 
     virtual uint32_t prepareNextFrame(VkCommandBufferInheritanceInfo const* inheritanceInfo) = 0;
     virtual void beginRenderPass(uint32_t imageIndex) = 0;

--- a/includes/FastEngine/graphic/C_view.hpp
+++ b/includes/FastEngine/graphic/C_view.hpp
@@ -118,9 +118,10 @@ public:
      *
      * \return A glm::mat4 of the view
      */
-    glm::mat4 const& getTransform() const;
-    glm::mat4 const& getInverseTransform() const;
-    glm::mat4 getProjectionMatrix() const;
+    [[nodiscard]] glm::mat4 const& getTransform() const;
+    [[nodiscard]] glm::mat4 const& getInverseTransform() const;
+    [[nodiscard]] glm::mat4 getProjectionMatrix() const;
+    [[nodiscard]] glm::mat4 getInverseProjectionMatrix() const;
 
 private:
     fge::Vector2f g_center;

--- a/sources/C_guiElement.cpp
+++ b/sources/C_guiElement.cpp
@@ -43,7 +43,7 @@ void GuiElementHandler::onMouseWheelScrolled(fge::Event const& evt, SDL_MouseWhe
     fge::GuiElementContext context{};
     context._mousePosition = {arg.x, arg.y};
     context._mouseGuiPosition =
-            this->g_target->mapPixelToCoords(context._mousePosition, this->g_target->getDefaultView());
+            this->g_target->mapFramebufferCoordsToWorldSpace(context._mousePosition, this->g_target->getDefaultView());
     context._handler = this;
 
     std::vector<fge::ObjectDataShared> keepAliveObject;
@@ -73,7 +73,7 @@ void GuiElementHandler::onMouseButtonPressed(fge::Event const& evt, SDL_MouseBut
     fge::GuiElementContext context{};
     context._mousePosition = {arg.x, arg.y};
     context._mouseGuiPosition =
-            this->g_target->mapPixelToCoords(context._mousePosition, this->g_target->getDefaultView());
+            this->g_target->mapFramebufferCoordsToWorldSpace(context._mousePosition, this->g_target->getDefaultView());
     context._handler = this;
 
     std::vector<fge::ObjectDataShared> keepAliveObject;
@@ -103,7 +103,7 @@ void GuiElementHandler::onMouseButtonReleased(fge::Event const& evt, SDL_MouseBu
     fge::GuiElementContext context{};
     context._mousePosition = {arg.x, arg.y};
     context._mouseGuiPosition =
-            this->g_target->mapPixelToCoords(context._mousePosition, this->g_target->getDefaultView());
+            this->g_target->mapFramebufferCoordsToWorldSpace(context._mousePosition, this->g_target->getDefaultView());
     context._handler = this;
 
     std::vector<fge::ObjectDataShared> keepAliveObject;
@@ -133,7 +133,7 @@ void GuiElementHandler::onMouseMoved(fge::Event const& evt, SDL_MouseMotionEvent
     fge::GuiElementContext context{};
     context._mousePosition = {arg.x, arg.y};
     context._mouseGuiPosition =
-            this->g_target->mapPixelToCoords(context._mousePosition, this->g_target->getDefaultView());
+            this->g_target->mapFramebufferCoordsToWorldSpace(context._mousePosition, this->g_target->getDefaultView());
     context._handler = this;
 
     std::vector<fge::ObjectDataShared> keepAliveObject;

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -753,14 +753,13 @@ std::size_t Scene::getAllObj_ByLocalPosition(fge::Vector2i const& pos,
                                              fge::ObjectContainer& buff) const
 {
     return this->getAllObj_ByPosition(
-            target.mapPixelToCoords(pos, this->g_customView ? *this->g_customView : target.getView()), buff);
+            target.mapFramebufferCoordsToWorldSpace(pos, this->g_customView ? *this->g_customView : target.getView()), buff);
 }
 std::size_t Scene::getAllObj_ByLocalZone(fge::RectInt const& zone,
                                          fge::RenderTarget const& target,
                                          fge::ObjectContainer& buff) const
 {
-    return this->getAllObj_ByZone(
-            fge::PixelToCoordRect(zone, target, this->g_customView ? *this->g_customView : target.getView()), buff);
+    return this->getAllObj_ByZone(target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()), buff);
 }
 std::size_t Scene::getAllObj_FromLocalPosition(fge::Vector2i const& pos,
                                                fge::RenderTarget const& target,
@@ -769,8 +768,7 @@ std::size_t Scene::getAllObj_FromLocalPosition(fge::Vector2i const& pos,
     std::size_t objCount = 0;
     for (auto const& data: this->g_data)
     {
-        auto objBounds = fge::CoordToPixelRect(data->g_object->getGlobalBounds(), target,
-                                               this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.contains(pos))
         {
             ++objCount;
@@ -786,8 +784,7 @@ std::size_t Scene::getAllObj_FromLocalZone(fge::RectInt const& zone,
     std::size_t objCount = 0;
     for (auto const& data: this->g_data)
     {
-        auto objBounds = fge::CoordToPixelRect(data->g_object->getGlobalBounds(), target,
-                                               this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.findIntersection(zone))
         {
             ++objCount;
@@ -857,12 +854,11 @@ fge::ObjectDataShared Scene::getFirstObj_ByLocalPosition(fge::Vector2i const& po
                                                          fge::RenderTarget const& target) const
 {
     return this->getFirstObj_ByPosition(
-            target.mapPixelToCoords(pos, this->g_customView ? *this->g_customView : target.getView()));
+            target.mapFramebufferCoordsToWorldSpace(pos, this->g_customView ? *this->g_customView : target.getView()));
 }
 fge::ObjectDataShared Scene::getFirstObj_ByLocalZone(fge::RectInt const& zone, fge::RenderTarget const& target) const
 {
-    return this->getFirstObj_ByZone(
-            fge::PixelToCoordRect(zone, target, this->g_customView ? *this->g_customView : target.getView()));
+    return this->getFirstObj_ByZone(target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()));
 }
 fge::ObjectDataShared Scene::getFirstObj_FromLocalPosition(fge::Vector2i const& pos,
                                                            fge::RenderTarget const& target) const
@@ -870,8 +866,7 @@ fge::ObjectDataShared Scene::getFirstObj_FromLocalPosition(fge::Vector2i const& 
     for (auto const& data: this->g_data)
     {
         fge::ObjectPtr const& buffObj = data->g_object;
-        auto objBounds = fge::CoordToPixelRect(buffObj->getGlobalBounds(), target,
-                                               this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.contains(pos))
         {
             return data;
@@ -884,8 +879,7 @@ fge::ObjectDataShared Scene::getFirstObj_FromLocalZone(fge::RectInt const& zone,
     for (auto const& data: this->g_data)
     {
         fge::ObjectPtr const& buffObj = data->g_object;
-        auto objBounds = fge::CoordToPixelRect(buffObj->getGlobalBounds(), target,
-                                               this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.findIntersection(zone))
         {
             return data;

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -753,13 +753,16 @@ std::size_t Scene::getAllObj_ByLocalPosition(fge::Vector2i const& pos,
                                              fge::ObjectContainer& buff) const
 {
     return this->getAllObj_ByPosition(
-            target.mapFramebufferCoordsToWorldSpace(pos, this->g_customView ? *this->g_customView : target.getView()), buff);
+            target.mapFramebufferCoordsToWorldSpace(pos, this->g_customView ? *this->g_customView : target.getView()),
+            buff);
 }
 std::size_t Scene::getAllObj_ByLocalZone(fge::RectInt const& zone,
                                          fge::RenderTarget const& target,
                                          fge::ObjectContainer& buff) const
 {
-    return this->getAllObj_ByZone(target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()), buff);
+    return this->getAllObj_ByZone(
+            target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()),
+            buff);
 }
 std::size_t Scene::getAllObj_FromLocalPosition(fge::Vector2i const& pos,
                                                fge::RenderTarget const& target,
@@ -768,7 +771,8 @@ std::size_t Scene::getAllObj_FromLocalPosition(fge::Vector2i const& pos,
     std::size_t objCount = 0;
     for (auto const& data: this->g_data)
     {
-        auto objBounds = target.mapViewRectToFramebufferSpace(data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(
+                data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.contains(pos))
         {
             ++objCount;
@@ -784,7 +788,8 @@ std::size_t Scene::getAllObj_FromLocalZone(fge::RectInt const& zone,
     std::size_t objCount = 0;
     for (auto const& data: this->g_data)
     {
-        auto objBounds = target.mapViewRectToFramebufferSpace(data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(
+                data->g_object->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.findIntersection(zone))
         {
             ++objCount;
@@ -858,7 +863,8 @@ fge::ObjectDataShared Scene::getFirstObj_ByLocalPosition(fge::Vector2i const& po
 }
 fge::ObjectDataShared Scene::getFirstObj_ByLocalZone(fge::RectInt const& zone, fge::RenderTarget const& target) const
 {
-    return this->getFirstObj_ByZone(target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()));
+    return this->getFirstObj_ByZone(
+            target.mapFramebufferRectToWorldSpace(zone, this->g_customView ? *this->g_customView : target.getView()));
 }
 fge::ObjectDataShared Scene::getFirstObj_FromLocalPosition(fge::Vector2i const& pos,
                                                            fge::RenderTarget const& target) const
@@ -866,7 +872,8 @@ fge::ObjectDataShared Scene::getFirstObj_FromLocalPosition(fge::Vector2i const& 
     for (auto const& data: this->g_data)
     {
         fge::ObjectPtr const& buffObj = data->g_object;
-        auto objBounds = target.mapViewRectToFramebufferSpace(buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(
+                buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.contains(pos))
         {
             return data;
@@ -879,7 +886,8 @@ fge::ObjectDataShared Scene::getFirstObj_FromLocalZone(fge::RectInt const& zone,
     for (auto const& data: this->g_data)
     {
         fge::ObjectPtr const& buffObj = data->g_object;
-        auto objBounds = target.mapViewRectToFramebufferSpace(buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
+        auto objBounds = target.mapViewRectToFramebufferSpace(
+                buffObj->getGlobalBounds(), this->g_customView ? *this->g_customView : target.getView());
         if (objBounds.findIntersection(zone))
         {
             return data;

--- a/sources/extra/extra_function.cpp
+++ b/sources/extra/extra_function.cpp
@@ -814,19 +814,21 @@ fge::View ClipView(fge::View const& view,
 ///Render
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target)
 {
-    fge::Vector2f positions[4] = {target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0)),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0)),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y)),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y))};
+    fge::Vector2f positions[4] = {
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0)),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0)),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y)),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y))};
 
     return fge::ToRect(positions, 4);
 }
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target, fge::View const& view)
 {
-    fge::Vector2f positions[4] = {target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0), view),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0), view),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y), view),
-                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
+    fge::Vector2f positions[4] = {
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0), view),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0), view),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y), view),
+            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
 
     return fge::ToRect(positions, 4);
 }

--- a/sources/extra/extra_function.cpp
+++ b/sources/extra/extra_function.cpp
@@ -415,7 +415,7 @@ bool IsMouseOn(fge::RenderTarget const& target, fge::RectFloat const& zone)
     int x = 0;
     int y = 0;
     SDL_GetMouseState(&x, &y);
-    return zone.contains(target.mapPixelToCoords({x, y}));
+    return zone.contains(target.mapFramebufferCoordsToViewSpace({x, y}));
 }
 bool IsMouseOn(fge::Vector2f const& mousePos, fge::RectFloat const& zone)
 {
@@ -677,7 +677,7 @@ fge::Vector2f SetViewSizePercentage(fge::Vector2f const& percentage, fge::View c
 fge::Vector2f
 TransposePointFromAnotherView(fge::View const& pointView, fge::Vector2f const& point, fge::View const& newView)
 {
-    fge::Vector2f const normalized = pointView.getTransform() * point;
+    fge::Vector2f const normalized = pointView.getProjectionMatrix() * pointView.getTransform() * point;
     return newView.getInverseTransform() * normalized;
 }
 
@@ -812,62 +812,21 @@ fge::View ClipView(fge::View const& view,
 }
 
 ///Render
-fge::RectInt CoordToPixelRect(fge::RectFloat const& rect, fge::RenderTarget const& target)
-{
-    fge::Vector2i positions[4] = {
-            target.mapCoordsToPixel(fge::Vector2f(rect._x, rect._y)),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x + rect._width, rect._y)),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x, rect._y + rect._height)),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x + rect._width, rect._y + rect._height))};
-
-    return fge::ToRect(positions, 4);
-}
-fge::RectInt CoordToPixelRect(fge::RectFloat const& rect, fge::RenderTarget const& target, fge::View const& view)
-{
-    fge::Vector2i positions[4] = {
-            target.mapCoordsToPixel(fge::Vector2f(rect._x, rect._y), view),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x + rect._width, rect._y), view),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x, rect._y + rect._height), view),
-            target.mapCoordsToPixel(fge::Vector2f(rect._x + rect._width, rect._y + rect._height), view)};
-
-    return fge::ToRect(positions, 4);
-}
-fge::RectFloat PixelToCoordRect(fge::RectInt const& rect, fge::RenderTarget const& target)
-{
-    fge::Vector2f positions[4] = {
-            target.mapPixelToCoords(fge::Vector2i(rect._x, rect._y)),
-            target.mapPixelToCoords(fge::Vector2i(rect._x + rect._width, rect._y)),
-            target.mapPixelToCoords(fge::Vector2i(rect._x, rect._y + rect._height)),
-            target.mapPixelToCoords(fge::Vector2i(rect._x + rect._width, rect._y + rect._height))};
-
-    return fge::ToRect(positions, 4);
-}
-fge::RectFloat PixelToCoordRect(fge::RectInt const& rect, fge::RenderTarget const& target, fge::View const& view)
-{
-    fge::Vector2f positions[4] = {
-            target.mapPixelToCoords(fge::Vector2i(rect._x, rect._y), view),
-            target.mapPixelToCoords(fge::Vector2i(rect._x + rect._width, rect._y), view),
-            target.mapPixelToCoords(fge::Vector2i(rect._x, rect._y + rect._height), view),
-            target.mapPixelToCoords(fge::Vector2i(rect._x + rect._width, rect._y + rect._height), view)};
-
-    return fge::ToRect(positions, 4);
-}
-
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target)
 {
-    fge::Vector2f positions[4] = {target.mapPixelToCoords(fge::Vector2i(0, 0)),
-                                  target.mapPixelToCoords(fge::Vector2i(target.getSize().x, 0)),
-                                  target.mapPixelToCoords(fge::Vector2i(0, target.getSize().y)),
-                                  target.mapPixelToCoords(fge::Vector2i(target.getSize().x, target.getSize().y))};
+    fge::Vector2f positions[4] = {target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0)),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0)),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y)),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y))};
 
     return fge::ToRect(positions, 4);
 }
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target, fge::View const& view)
 {
-    fge::Vector2f positions[4] = {target.mapPixelToCoords(fge::Vector2i(0, 0), view),
-                                  target.mapPixelToCoords(fge::Vector2i(target.getSize().x, 0), view),
-                                  target.mapPixelToCoords(fge::Vector2i(0, target.getSize().y), view),
-                                  target.mapPixelToCoords(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
+    fge::Vector2f positions[4] = {target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0), view),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0), view),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y), view),
+                                  target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
 
     return fge::ToRect(positions, 4);
 }

--- a/sources/extra/extra_function.cpp
+++ b/sources/extra/extra_function.cpp
@@ -678,7 +678,7 @@ fge::Vector2f
 TransposePointFromAnotherView(fge::View const& pointView, fge::Vector2f const& point, fge::View const& newView)
 {
     fge::Vector2f const normalized = pointView.getProjectionMatrix() * pointView.getTransform() * point;
-    return newView.getInverseTransform() * normalized;
+    return newView.getInverseTransform() * newView.getInverseProjectionMatrix() * normalized;
 }
 
 fge::View ClipView(fge::View const& view,
@@ -815,20 +815,20 @@ fge::View ClipView(fge::View const& view,
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target)
 {
     fge::Vector2f positions[4] = {
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0)),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0)),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y)),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y))};
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(0, 0)),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(target.getSize().x, 0)),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(0, target.getSize().y)),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(target.getSize().x, target.getSize().y))};
 
     return fge::ToRect(positions, 4);
 }
 fge::RectFloat GetScreenRect(fge::RenderTarget const& target, fge::View const& view)
 {
     fge::Vector2f positions[4] = {
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, 0), view),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, 0), view),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(0, target.getSize().y), view),
-            target.mapFramebufferCoordsToViewSpace(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(0, 0), view),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(target.getSize().x, 0), view),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(0, target.getSize().y), view),
+            target.mapFramebufferCoordsToWorldSpace(fge::Vector2i(target.getSize().x, target.getSize().y), view)};
 
     return fge::ToRect(positions, 4);
 }

--- a/sources/extra/extra_string.cpp
+++ b/sources/extra/extra_string.cpp
@@ -332,13 +332,55 @@ std::string ToStr(float val)
 {
     return fmt::format(FMT_COMPILE("{}"), val);
 }
+std::string ToStr(float val, unsigned int precision, bool keepExtraZeros)
+{
+    std::string result = fmt::format(FMT_COMPILE("{:.{}f}"), val, precision);
+    if (!keepExtraZeros)
+    {
+        auto pos = result.find_last_not_of('0');
+        pos += 1 + static_cast<unsigned>(result[pos] == '.');
+        if (pos < result.length())
+        {
+            result.erase(pos, std::string::npos);
+        }
+    }
+    return result;
+}
 std::string ToStr(double val)
 {
     return fmt::format(FMT_COMPILE("{}"), val);
 }
+std::string ToStr(double val, unsigned int precision, bool keepExtraZeros)
+{
+    std::string result = fmt::format(FMT_COMPILE("{:.{}f}"), val, precision);
+    if (!keepExtraZeros)
+    {
+        auto pos = result.find_last_not_of('0');
+        pos += 1 + static_cast<unsigned>(result[pos] == '.');
+        if (pos < result.length())
+        {
+            result.erase(pos, std::string::npos);
+        }
+    }
+    return result;
+}
 std::string ToStr(long double val)
 {
     return fmt::format(FMT_COMPILE("{}"), val);
+}
+std::string ToStr(long double val, unsigned int precision, bool keepExtraZeros)
+{
+    std::string result = fmt::format(FMT_COMPILE("{:.{}f}"), val, precision);
+    if (!keepExtraZeros)
+    {
+        auto pos = result.find_last_not_of('0');
+        pos += 1 + static_cast<unsigned>(result[pos] == '.');
+        if (pos < result.length())
+        {
+            result.erase(pos, std::string::npos);
+        }
+    }
+    return result;
 }
 
 //Pointer

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -16,12 +16,12 @@
 
 #include "FastEngine/graphic/C_renderTarget.hpp"
 #include "FastEngine/C_texture.hpp"
+#include "FastEngine/extra/extra_function.hpp"
 #include "FastEngine/graphic/C_drawable.hpp"
 #include "FastEngine/graphic/C_transformable.hpp"
 #include "FastEngine/manager/shader_manager.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/C_textureImage.hpp"
-#include "FastEngine/extra/extra_function.hpp"
 
 namespace fge
 {
@@ -169,15 +169,13 @@ Vector2i RenderTarget::mapViewCoordsToFramebufferSpace(Vector2f const& point, Vi
     glm::vec4 ndc = view.getProjectionMatrix() * pointVec4;
 
     // Transform the NDC to framebuffer space with the viewport
-    ndc.x = (ndc.x+1.0f) / 2.0f;
-    ndc.y = (-ndc.y+1.0f) / 2.0f;
+    ndc.x = (ndc.x + 1.0f) / 2.0f;
+    ndc.y = (-ndc.y + 1.0f) / 2.0f;
 
     auto const viewport = this->getViewport(view);
 
-    Vector2i const pixel{
-        static_cast<int>(ndc.x * viewport.getWidth() + viewport.getPositionX()),
-        static_cast<int>(ndc.y * viewport.getHeight() + viewport.getPositionY())
-    };
+    Vector2i const pixel{static_cast<int>(ndc.x * viewport.getWidth() + viewport.getPositionX()),
+                         static_cast<int>(ndc.y * viewport.getHeight() + viewport.getPositionY())};
 
     return pixel;
 }
@@ -197,10 +195,10 @@ RectFloat RenderTarget::mapFramebufferRectToViewSpace(RectInt const& rect) const
 RectFloat RenderTarget::mapFramebufferRectToViewSpace(RectInt const& rect, View const& view) const
 {
     Vector2f const positions[4] = {
-        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y}, view),
-        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y}, view),
-        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y + rect._height}, view),
-        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
+            this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y}, view),
+            this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y}, view),
+            this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y + rect._height}, view),
+            this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
 
     return ToRect(positions, 4);
 }
@@ -211,10 +209,10 @@ RectFloat RenderTarget::mapFramebufferRectToWorldSpace(RectInt const& rect) cons
 RectFloat RenderTarget::mapFramebufferRectToWorldSpace(RectInt const& rect, View const& view) const
 {
     Vector2f const positions[4] = {
-        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y}, view),
-        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y}, view),
-        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y + rect._height}, view),
-        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
+            this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y}, view),
+            this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y}, view),
+            this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y + rect._height}, view),
+            this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
 
     return ToRect(positions, 4);
 }
@@ -226,10 +224,10 @@ RectInt RenderTarget::mapViewRectToFramebufferSpace(RectFloat const& rect) const
 RectInt RenderTarget::mapViewRectToFramebufferSpace(RectFloat const& rect, View const& view) const
 {
     Vector2i const positions[4] = {
-        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
-        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
-        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
-        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
+            this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
+            this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
+            this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
+            this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
 
     return ToRect(positions, 4);
 }
@@ -240,10 +238,10 @@ RectInt RenderTarget::mapWorldRectToFramebufferSpace(RectFloat const& rect) cons
 RectInt RenderTarget::mapWorldRectToFramebufferSpace(RectFloat const& rect, View const& view) const
 {
     Vector2i const positions[4] = {
-        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
-        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
-        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
-        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
+            this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
+            this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
+            this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
+            this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
 
     return ToRect(positions, 4);
 }
@@ -285,7 +283,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
     //Apply view transform
     if (states._resTransform.get() != nullptr)
     {
-        states._resTransform.get()->getData()._viewTransform = this->getView().getProjectionMatrix() * this->getView().getTransform();
+        states._resTransform.get()->getData()._viewTransform =
+                this->getView().getProjectionMatrix() * this->getView().getTransform();
     }
 
     //Updating graphicPipeline

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -21,6 +21,7 @@
 #include "FastEngine/manager/shader_manager.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
 #include "FastEngine/vulkan/C_textureImage.hpp"
+#include "FastEngine/extra/extra_function.hpp"
 
 namespace fge
 {
@@ -131,41 +132,120 @@ fge::vulkan::Viewport RenderTarget::getViewport(View const& view) const
     return {size.x * viewport._x, size.y * viewport._y, size.x * viewport._width, size.y * viewport._height};
 }
 
-Vector2f RenderTarget::mapPixelToCoords(Vector2i const& point) const
+Vector2f RenderTarget::mapFramebufferCoordsToViewSpace(Vector2i const& point) const
 {
-    return this->mapPixelToCoords(point, this->getView());
+    return this->mapFramebufferCoordsToViewSpace(point, this->getView());
 }
-Vector2f RenderTarget::mapPixelToCoords(Vector2i const& point, View const& view) const
+Vector2f RenderTarget::mapFramebufferCoordsToViewSpace(Vector2i const& point, View const& view) const
 {
-    // First, convert from viewport coordinates to homogeneous coordinates
+    // Transform the point to normalized device coordinates (assuming it's already in homogeneous coordinates)
     glm::vec4 normalized;
-    auto viewport = this->getViewport(view);
+    auto const viewport = this->getViewport(view);
     normalized.x = -1.f + 2.f * (static_cast<float>(point.x) - viewport.getPositionX()) / viewport.getWidth();
     normalized.y = 1.f - 2.f * (static_cast<float>(point.y) - viewport.getPositionY()) / viewport.getHeight();
     normalized.z = 0.0f;
     normalized.w = 1.0f;
 
-    // Then transform by the inverse of the view matrix
-    return view.getInverseTransform() * normalized;
+    // Transform the homogeneous coordinates to world coordinates
+    return view.getInverseProjectionMatrix() * normalized;
 }
-Vector2i RenderTarget::mapCoordsToPixel(Vector2f const& point) const
+Vector2f RenderTarget::mapFramebufferCoordsToWorldSpace(Vector2i const& point) const
 {
-    return this->mapCoordsToPixel(point, this->getView());
+    return this->mapFramebufferCoordsToWorldSpace(point, this->getView());
 }
-Vector2i RenderTarget::mapCoordsToPixel(Vector2f const& point, View const& view) const
+Vector2f RenderTarget::mapFramebufferCoordsToWorldSpace(Vector2i const& point, View const& view) const
+{
+    return view.getInverseTransform() * this->mapFramebufferCoordsToViewSpace(point, view);
+}
+Vector2i RenderTarget::mapViewCoordsToFramebufferSpace(Vector2f const& point) const
+{
+    return this->mapViewCoordsToFramebufferSpace(point, this->getView());
+}
+Vector2i RenderTarget::mapViewCoordsToFramebufferSpace(Vector2f const& point, View const& view) const
 {
     glm::vec4 const pointVec4(point, 0.0f, 1.0f);
 
-    // First, transform the point by the view matrix
-    glm::vec4 const normalized = view.getTransform() * pointVec4;
+    // Transform the point to clip space (assuming it's already NDC)
+    glm::vec4 ndc = view.getProjectionMatrix() * pointVec4;
 
-    // Then convert to viewport coordinates
-    Vector2i pixel;
-    auto viewport = this->getViewport(view);
-    pixel.x = static_cast<int>((normalized.x + 1.f) / 2.f * viewport.getWidth() + viewport.getPositionX());
-    pixel.y = static_cast<int>((-normalized.y + 1.f) / 2.f * viewport.getHeight() + viewport.getPositionY());
+    // Transform the NDC to framebuffer space with the viewport
+    ndc.x = (ndc.x+1.0f) / 2.0f;
+    ndc.y = (-ndc.y+1.0f) / 2.0f;
+
+    auto const viewport = this->getViewport(view);
+
+    Vector2i const pixel{
+        static_cast<int>(ndc.x * viewport.getWidth() + viewport.getPositionX()),
+        static_cast<int>(ndc.y * viewport.getHeight() + viewport.getPositionY())
+    };
 
     return pixel;
+}
+Vector2i RenderTarget::mapWorldCoordsToFramebufferSpace(Vector2f const& point) const
+{
+    return this->mapWorldCoordsToFramebufferSpace(point, this->getView());
+}
+Vector2i RenderTarget::mapWorldCoordsToFramebufferSpace(Vector2f const& point, View const& view) const
+{
+    return this->mapViewCoordsToFramebufferSpace(view.getTransform() * point, view);
+}
+
+RectFloat RenderTarget::mapFramebufferRectToViewSpace(RectInt const& rect) const
+{
+    return this->mapFramebufferRectToViewSpace(rect, this->getView());
+}
+RectFloat RenderTarget::mapFramebufferRectToViewSpace(RectInt const& rect, View const& view) const
+{
+    Vector2f const positions[4] = {
+        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y}, view),
+        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y}, view),
+        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x, rect._y + rect._height}, view),
+        this->mapFramebufferCoordsToViewSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
+
+    return ToRect(positions, 4);
+}
+RectFloat RenderTarget::mapFramebufferRectToWorldSpace(RectInt const& rect) const
+{
+    return this->mapFramebufferRectToWorldSpace(rect, this->getView());
+}
+RectFloat RenderTarget::mapFramebufferRectToWorldSpace(RectInt const& rect, View const& view) const
+{
+    Vector2f const positions[4] = {
+        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y}, view),
+        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y}, view),
+        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x, rect._y + rect._height}, view),
+        this->mapFramebufferCoordsToWorldSpace(Vector2i{rect._x + rect._width, rect._y + rect._height}, view)};
+
+    return ToRect(positions, 4);
+}
+
+RectInt RenderTarget::mapViewRectToFramebufferSpace(RectFloat const& rect) const
+{
+    return this->mapViewRectToFramebufferSpace(rect, this->getView());
+}
+RectInt RenderTarget::mapViewRectToFramebufferSpace(RectFloat const& rect, View const& view) const
+{
+    Vector2i const positions[4] = {
+        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
+        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
+        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
+        this->mapViewCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
+
+    return ToRect(positions, 4);
+}
+RectInt RenderTarget::mapWorldRectToFramebufferSpace(RectFloat const& rect) const
+{
+    return this->mapWorldRectToFramebufferSpace(rect, this->getView());
+}
+RectInt RenderTarget::mapWorldRectToFramebufferSpace(RectFloat const& rect, View const& view) const
+{
+    Vector2i const positions[4] = {
+        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y}, view),
+        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y}, view),
+        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x, rect._y + rect._height}, view),
+        this->mapWorldCoordsToFramebufferSpace(Vector2f{rect._x + rect._width, rect._y + rect._height}, view)};
+
+    return ToRect(positions, 4);
 }
 
 void RenderTarget::draw(Drawable const& drawable, RenderStates const& states)
@@ -205,7 +285,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
     //Apply view transform
     if (states._resTransform.get() != nullptr)
     {
-        states._resTransform.get()->getData()._viewTransform = this->getView().getTransform();
+        states._resTransform.get()->getData()._viewTransform = this->getView().getProjectionMatrix() * this->getView().getTransform();
     }
 
     //Updating graphicPipeline

--- a/sources/graphic/C_view.cpp
+++ b/sources/graphic/C_view.cpp
@@ -139,9 +139,7 @@ glm::mat4 const& View::getTransform() const
 {
     if (!this->g_transformUpdated)
     {
-        this->g_transform = glm::ortho<float>(0.0f, this->g_size.x, this->g_size.y, 0.0f);
-
-        this->g_transform = glm::translate(this->g_transform, glm::vec3{this->g_size / 2.0f - this->g_center, 0.0f});
+        this->g_transform = glm::translate(glm::mat4{1.0f}, glm::vec3{this->g_size / 2.0f - this->g_center, 0.0f});
 
         this->g_transform = glm::translate(this->g_transform, glm::vec3{this->g_center, 0.0f});
         this->g_transform =
@@ -166,6 +164,10 @@ glm::mat4 const& View::getInverseTransform() const
 glm::mat4 View::getProjectionMatrix() const
 {
     return glm::ortho<float>(0.0f, this->g_size.x, this->g_size.y, 0.0f);
+}
+glm::mat4 View::getInverseProjectionMatrix() const
+{
+    return glm::inverse(this->getProjectionMatrix());
 }
 
 } // namespace fge

--- a/sources/object/C_objButton.cpp
+++ b/sources/object/C_objButton.cpp
@@ -187,11 +187,11 @@ void ObjButton::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objButton.cpp
+++ b/sources/object/C_objButton.cpp
@@ -187,11 +187,13 @@ void ObjButton::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition,
+                                                                                                 *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
+            mousePosition =
+                    context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objSelectBox.cpp
+++ b/sources/object/C_objSelectBox.cpp
@@ -331,11 +331,11 @@ void ObjSelectBox::onGuiMouseMotion([[maybe_unused]] fge::Event const& evt,
     fge::Vector2f mousePosition;
     if (customView)
     {
-        mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition, *customView);
+        mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
     }
     else
     {
-        mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition);
+        mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
     }
 
     auto transform = this->getParentsTransform() * this->getTransform();
@@ -393,11 +393,11 @@ void ObjSelectBox::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (boxRect.contains(mousePosition))

--- a/sources/object/C_objSelectBox.cpp
+++ b/sources/object/C_objSelectBox.cpp
@@ -331,7 +331,8 @@ void ObjSelectBox::onGuiMouseMotion([[maybe_unused]] fge::Event const& evt,
     fge::Vector2f mousePosition;
     if (customView)
     {
-        mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
+        mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition,
+                                                                                             *customView);
     }
     else
     {
@@ -393,11 +394,13 @@ void ObjSelectBox::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition,
+                                                                                                 *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
+            mousePosition =
+                    context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (boxRect.contains(mousePosition))

--- a/sources/object/C_objSlider.cpp
+++ b/sources/object/C_objSlider.cpp
@@ -125,7 +125,7 @@ void ObjSlider::onGuiMouseButtonPressed([[maybe_unused]] fge::Event const& evt,
                                         [[maybe_unused]] SDL_MouseButtonEvent const& arg,
                                         fge::GuiElementContext& context)
 {
-    auto mousePosition = context._handler->getRenderTarget().mapPixelToCoords(
+    auto mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(
             {context._mousePosition.x, context._mousePosition.y},
             *this->_myObjectData.lock()->getLinkedScene()->getRelatedView());
 
@@ -149,7 +149,7 @@ void ObjSlider::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     {
         fge::RenderTarget const& renderTarget = this->g_guiElementHandler->getRenderTarget();
 
-        fge::Vector2f mousePos = renderTarget.mapPixelToCoords(
+        fge::Vector2f mousePos = renderTarget.mapFramebufferCoordsToWorldSpace(
                 {arg.x, arg.y}, *this->_myObjectData.lock()->getLinkedScene()->getRelatedView());
 
         auto scale = this->getParentsScale().y * this->getScale().y;
@@ -189,11 +189,11 @@ void ObjSlider::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objSlider.cpp
+++ b/sources/object/C_objSlider.cpp
@@ -189,11 +189,13 @@ void ObjSlider::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition,
+                                                                                                 *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
+            mousePosition =
+                    context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -253,7 +253,7 @@ FGE_OBJ_DRAW_BODY(ObjSpriteBatches)
 
     //Update the view matrix (always the first element of the buffer)
     auto* view = static_cast<InstanceDataBuffer*>(this->g_instancesTransform.getBufferMapped());
-    view->_transform = target.getView().getTransform();
+    view->_transform = target.getView().getProjectionMatrix() * target.getView().getTransform();
 
     //Update all model matrices
     for (std::size_t i = 0; i < this->g_instancesData.size(); ++i)

--- a/sources/object/C_objSwitch.cpp
+++ b/sources/object/C_objSwitch.cpp
@@ -69,7 +69,7 @@ FGE_OBJ_UPDATE_BODY(ObjSwitch) {}
 #else
 FGE_OBJ_UPDATE_BODY(ObjSwitch)
 {
-    this->g_statMouseOn = fge::IsMouseOn(screen.mapPixelToCoords(event.getMousePixelPos()), this->getGlobalBounds());
+    this->g_statMouseOn = fge::IsMouseOn(screen.mapFramebufferCoordsToWorldSpace(event.getMousePixelPos()), this->getGlobalBounds());
 
     if (this->g_flag.check(event.isMouseButtonPressed(SDL_BUTTON_LEFT)))
     {

--- a/sources/object/C_objSwitch.cpp
+++ b/sources/object/C_objSwitch.cpp
@@ -69,7 +69,8 @@ FGE_OBJ_UPDATE_BODY(ObjSwitch) {}
 #else
 FGE_OBJ_UPDATE_BODY(ObjSwitch)
 {
-    this->g_statMouseOn = fge::IsMouseOn(screen.mapFramebufferCoordsToWorldSpace(event.getMousePixelPos()), this->getGlobalBounds());
+    this->g_statMouseOn =
+            fge::IsMouseOn(screen.mapFramebufferCoordsToWorldSpace(event.getMousePixelPos()), this->getGlobalBounds());
 
     if (this->g_flag.check(event.isMouseButtonPressed(SDL_BUTTON_LEFT)))
     {

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -411,7 +411,8 @@ FGE_OBJ_DRAW_BODY(ObjText)
                         reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
                 transformData->_modelTransform =
                         copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
-                transformData->_viewTransform = target.getView().getProjectionMatrix() * target.getView().getTransform();
+                transformData->_viewTransform =
+                        target.getView().getProjectionMatrix() * target.getView().getTransform();
 
                 if (!character.g_visibility)
                 {
@@ -445,7 +446,8 @@ FGE_OBJ_DRAW_BODY(ObjText)
                         reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
                 transformData->_modelTransform =
                         copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
-                transformData->_viewTransform = target.getView().getProjectionMatrix() * target.getView().getTransform();
+                transformData->_viewTransform =
+                        target.getView().getProjectionMatrix() * target.getView().getTransform();
             }
 
             uint32_t dynamicBufferSize = fge::TransformUboData::uboSize;

--- a/sources/object/C_objText.cpp
+++ b/sources/object/C_objText.cpp
@@ -411,7 +411,7 @@ FGE_OBJ_DRAW_BODY(ObjText)
                         reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
                 transformData->_modelTransform =
                         copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
-                transformData->_viewTransform = target.getView().getTransform();
+                transformData->_viewTransform = target.getView().getProjectionMatrix() * target.getView().getTransform();
 
                 if (!character.g_visibility)
                 {
@@ -445,7 +445,7 @@ FGE_OBJ_DRAW_BODY(ObjText)
                         reinterpret_cast<fge::TransformUboData*>(this->g_charactersTransforms.getBufferMapped()) + i;
                 transformData->_modelTransform =
                         copyStates._resTransform.get()->getData()._modelTransform * character.getTransform();
-                transformData->_viewTransform = target.getView().getTransform();
+                transformData->_viewTransform = target.getView().getProjectionMatrix() * target.getView().getTransform();
             }
 
             uint32_t dynamicBufferSize = fge::TransformUboData::uboSize;

--- a/sources/object/C_objTextinputbox.cpp
+++ b/sources/object/C_objTextinputbox.cpp
@@ -448,11 +448,13 @@ void ObjTextInputBox::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition,
+                                                                                                 *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
+            mousePosition =
+                    context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objTextinputbox.cpp
+++ b/sources/object/C_objTextinputbox.cpp
@@ -448,11 +448,11 @@ void ObjTextInputBox::onGuiVerify([[maybe_unused]] fge::Event const& evt,
         fge::Vector2f mousePosition;
         if (customView)
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition, *customView);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition, *customView);
         }
         else
         {
-            mousePosition = context._handler->getRenderTarget().mapPixelToCoords(context._mousePosition);
+            mousePosition = context._handler->getRenderTarget().mapFramebufferCoordsToWorldSpace(context._mousePosition);
         }
 
         if (scrollRect.contains(mousePosition))

--- a/sources/object/C_objWindow.cpp
+++ b/sources/object/C_objWindow.cpp
@@ -421,7 +421,7 @@ void ObjWindow::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     {
         fge::RenderTarget const& renderTarget = this->g_guiElementHandler->getRenderTarget();
 
-        fge::Vector2f mousePos = renderTarget.mapPixelToCoords({arg.x, arg.y}, renderTarget.getDefaultView());
+        fge::Vector2f mousePos = renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
 
         fge::Vector2f newPosition = mousePos + this->g_mouseClickLastPosition;
         newPosition.x = std::clamp(newPosition.x, 0.0f,
@@ -436,7 +436,7 @@ void ObjWindow::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     {
         fge::RenderTarget const& renderTarget = this->g_guiElementHandler->getRenderTarget();
 
-        fge::Vector2f mousePos = renderTarget.mapPixelToCoords({arg.x, arg.y}, renderTarget.getDefaultView());
+        fge::Vector2f mousePos = renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
 
         fge::Vector2f mouseDiff{this->g_resizeModeX == ObjWindow::ResizeModes::MODE_FREE
                                         ? (mousePos.x - this->g_mouseClickLastPosition.x) / this->getScale().x

--- a/sources/object/C_objWindow.cpp
+++ b/sources/object/C_objWindow.cpp
@@ -421,7 +421,8 @@ void ObjWindow::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     {
         fge::RenderTarget const& renderTarget = this->g_guiElementHandler->getRenderTarget();
 
-        fge::Vector2f mousePos = renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
+        fge::Vector2f mousePos =
+                renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
 
         fge::Vector2f newPosition = mousePos + this->g_mouseClickLastPosition;
         newPosition.x = std::clamp(newPosition.x, 0.0f,
@@ -436,7 +437,8 @@ void ObjWindow::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     {
         fge::RenderTarget const& renderTarget = this->g_guiElementHandler->getRenderTarget();
 
-        fge::Vector2f mousePos = renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
+        fge::Vector2f mousePos =
+                renderTarget.mapFramebufferCoordsToWorldSpace({arg.x, arg.y}, renderTarget.getDefaultView());
 
         fge::Vector2f mouseDiff{this->g_resizeModeX == ObjWindow::ResizeModes::MODE_FREE
                                         ? (mousePos.x - this->g_mouseClickLastPosition.x) / this->getScale().x


### PR DESCRIPTION
- Separate projection from the view matrix
- - allow more math control
- Rename all map* methods from RenderTarget class to be more coherent with how Vulkan work
- Also add the ability to map to/from worldCoords/viewCoords
- Add config macros : GLM_FORCE_DEPTH_ZERO_TO_ONE and GLM_FORCE_LEFT_HANDED
- 3 new math functions : 
- - Add ConvertRange()
- - Add MapCircleToSquareCoords()
- - Add MapSquareToCircleCoords()
- Also add precision control over string to floating points
