### PR TITLE
New command buffer class

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CMakePythonSetting">
+    <option name="pythonIntegrationState" value="YES" />
+  </component>
   <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
   <component name="CidrRootsConfiguration">
     <sourceRoots>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ target_sources(${FGE_SERVER_LIB_NAME} PRIVATE
         sources/vulkan/C_descriptorSetLayout.cpp
         sources/vulkan/C_garbageCollector.cpp
         sources/vulkan/C_context.cpp
+        sources/vulkan/C_commandBuffer.cpp
         sources/vulkan/C_graphicPipeline.cpp
         sources/vulkan/C_viewport.cpp)
 
@@ -323,6 +324,7 @@ target_sources(${FGE_LIB_NAME} PRIVATE
         sources/vulkan/C_descriptorSetLayout.cpp
         sources/vulkan/C_garbageCollector.cpp
         sources/vulkan/C_context.cpp
+        sources/vulkan/C_commandBuffer.cpp
         sources/vulkan/C_graphicPipeline.cpp
         sources/vulkan/C_viewport.cpp)
 

--- a/examples/mipmaps_007/main.cpp
+++ b/examples/mipmaps_007/main.cpp
@@ -179,8 +179,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
         return 1;
     }
 
-    fge::vulkan::ValidationLayers.clear();
-    fge::vulkan::ValidationLayers.push_back("VK_LAYER_LUNARG_monitor");
+    fge::vulkan::InstanceLayers.clear();
+    fge::vulkan::InstanceLayers.push_back("VK_LAYER_LUNARG_monitor");
 
     fge::vulkan::Context vulkanContext{};
     fge::vulkan::Context::initVolk();

--- a/examples/multipleSprites_006/main.cpp
+++ b/examples/multipleSprites_006/main.cpp
@@ -288,8 +288,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
         return 1;
     }
 
-    fge::vulkan::ValidationLayers.clear();
-    fge::vulkan::ValidationLayers.push_back("VK_LAYER_LUNARG_monitor");
+    fge::vulkan::InstanceLayers.clear();
+    fge::vulkan::InstanceLayers.push_back("VK_LAYER_LUNARG_monitor");
 
     fge::vulkan::Context vulkanContext{};
     fge::vulkan::Context::initVolk();

--- a/includes/FastEngine/graphic/C_renderTarget.hpp
+++ b/includes/FastEngine/graphic/C_renderTarget.hpp
@@ -31,6 +31,7 @@
 #include "FastEngine/graphic/C_renderStates.hpp"
 #include "FastEngine/graphic/C_view.hpp"
 #include "FastEngine/vulkan/C_blendMode.hpp"
+#include "FastEngine/vulkan/C_commandBuffer.hpp"
 #include "FastEngine/vulkan/C_contextAware.hpp"
 #include "FastEngine/vulkan/C_descriptorSet.hpp"
 #include "FastEngine/vulkan/C_graphicPipeline.hpp"
@@ -137,7 +138,7 @@ public:
     virtual Vector2u getSize() const = 0;
 
     [[nodiscard]] virtual VkExtent2D getExtent2D() const = 0;
-    [[nodiscard]] virtual VkCommandBuffer getCommandBuffer() const = 0;
+    [[nodiscard]] virtual fge::vulkan::CommandBuffer& getCommandBuffer() const = 0;
     [[nodiscard]] virtual VkRenderPass getRenderPass() const = 0;
 
     [[nodiscard]] fge::vulkan::GraphicPipeline* getGraphicPipeline(std::string_view name,

--- a/includes/FastEngine/graphic/C_renderTexture.hpp
+++ b/includes/FastEngine/graphic/C_renderTexture.hpp
@@ -60,7 +60,7 @@ public:
     Vector2u getSize() const override;
 
     [[nodiscard]] VkExtent2D getExtent2D() const override;
-    [[nodiscard]] VkCommandBuffer getCommandBuffer() const override;
+    [[nodiscard]] fge::vulkan::CommandBuffer& getCommandBuffer() const override;
     [[nodiscard]] VkRenderPass getRenderPass() const override;
 
     [[nodiscard]] fge::vulkan::TextureImage const& getTextureImage() const;
@@ -80,7 +80,7 @@ private:
 
     VkFramebuffer g_framebuffer;
 
-    std::array<VkCommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT> g_commandBuffers;
+    mutable std::array<fge::vulkan::CommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT> g_commandBuffers;
 
     uint32_t g_currentFrame;
 

--- a/includes/FastEngine/graphic/C_renderWindow.hpp
+++ b/includes/FastEngine/graphic/C_renderWindow.hpp
@@ -63,7 +63,7 @@ public:
     [[nodiscard]] VkPresentModeKHR getPresentMode() const;
 
     [[nodiscard]] VkExtent2D getExtent2D() const override;
-    [[nodiscard]] VkCommandBuffer getCommandBuffer() const override;
+    [[nodiscard]] fge::vulkan::CommandBuffer& getCommandBuffer() const override;
     [[nodiscard]] VkRenderPass getRenderPass() const override;
 
     [[nodiscard]] VkCommandBufferInheritanceInfo getInheritanceInfo(uint32_t imageIndex) const;
@@ -89,7 +89,7 @@ private:
 
     std::vector<VkFramebuffer> g_swapChainFramebuffers;
 
-    std::array<VkCommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT> g_commandBuffers;
+    mutable std::array<fge::vulkan::CommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT> g_commandBuffers;
 
     std::array<VkSemaphore, FGE_MAX_FRAMES_IN_FLIGHT> g_imageAvailableSemaphores;
     std::array<VkSemaphore, FGE_MAX_FRAMES_IN_FLIGHT> g_renderFinishedSemaphores;

--- a/includes/FastEngine/vulkan/C_commandBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_commandBuffer.hpp
@@ -33,13 +33,6 @@ namespace fge::vulkan
 class FGE_API CommandBuffer : public ContextAware
 {
 public:
-    enum class SubmitTypes
-    {
-        DIRECT_EXECUTION,
-        INDIRECT_EXECUTION,
-        INDIRECT_ISOLATED_EXECUTION
-    };
-
     enum class RenderPassScopes
     {
         INSIDE,
@@ -57,15 +50,20 @@ public:
     };
     using SupportedQueueTypes_t = std::underlying_type_t<SupportedQueueTypes>;
 
-    CommandBuffer(Context const& context, VkCommandBufferLevel level, SubmitTypes type, VkCommandPool commandPool);
+    CommandBuffer(Context const& context, VkCommandBufferLevel level, VkCommandPool commandPool);
+    CommandBuffer(Context const& context,
+                  VkCommandBufferLevel level,
+                  VkCommandBuffer commandBuffer,
+                  VkCommandPool commandPool);
     CommandBuffer(CommandBuffer const& r) = delete;
-    CommandBuffer(CommandBuffer&& r) noexcept = delete;
+    CommandBuffer(CommandBuffer&& r) noexcept;
     ~CommandBuffer() override;
 
     CommandBuffer& operator=(CommandBuffer const& r) = delete;
-    CommandBuffer& operator=(CommandBuffer&& r) noexcept = delete;
+    CommandBuffer& operator=(CommandBuffer&& r) noexcept;
 
-    void create(VkCommandBufferLevel level, SubmitTypes type, VkCommandPool commandPool);
+    void create(VkCommandBufferLevel level, VkCommandPool commandPool);
+    void create(VkCommandBufferLevel level, VkCommandBuffer commandBuffer, VkCommandPool commandPool);
     void destroy() final;
     [[nodiscard]] std::pair<VkCommandBuffer, VkCommandPool> release();
 
@@ -73,13 +71,19 @@ public:
     void begin(VkCommandBufferUsageFlags flags);
     void end();
 
-    [[nodiscard]] SubmitTypes getSubmitType() const;
     [[nodiscard]] VkCommandBuffer get() const;
+    [[nodiscard]] VkCommandBuffer const* getPtr() const;
     [[nodiscard]] VkCommandPool getPool() const;
     [[nodiscard]] VkCommandBufferLevel getLevel() const;
     [[nodiscard]] RenderPassScopes getRenderPassScope() const;
     [[nodiscard]] SupportedQueueTypes_t getSupportedQueues() const;
+    [[nodiscard]] uint32_t getRecordedCommandsCount() const;
     [[nodiscard]] bool isEnded() const;
+
+    void forceEnd();
+    void forceRenderPassScope(RenderPassScopes scope);
+    void forceSupportedQueues(SupportedQueueTypes_t queues);
+    void forceRecordedCommandsCount(uint32_t count);
 
     /**
      * \brief Copy a buffer to another
@@ -156,12 +160,12 @@ public:
                           int32_t offsetY = 0);
 
 private:
-    SubmitTypes g_type;
     VkCommandBuffer g_commandBuffer;
     VkCommandPool g_commandPool;
     VkCommandBufferLevel g_level;
     RenderPassScopes g_renderPassScope;
     SupportedQueueTypes_t g_queueType;
+    uint32_t g_recordedCommands;
     bool g_isEnded;
 };
 

--- a/includes/FastEngine/vulkan/C_commandBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_commandBuffer.hpp
@@ -50,6 +50,7 @@ public:
     };
     using SupportedQueueTypes_t = std::underlying_type_t<SupportedQueueTypes>;
 
+    CommandBuffer(Context const& context);
     CommandBuffer(Context const& context, VkCommandBufferLevel level, VkCommandPool commandPool);
     CommandBuffer(Context const& context,
                   VkCommandBufferLevel level,
@@ -68,7 +69,7 @@ public:
     [[nodiscard]] std::pair<VkCommandBuffer, VkCommandPool> release();
 
     void reset();
-    void begin(VkCommandBufferUsageFlags flags);
+    void begin(VkCommandBufferUsageFlags flags, VkCommandBufferInheritanceInfo const* inheritanceInfo = nullptr);
     void end();
 
     [[nodiscard]] VkCommandBuffer get() const;
@@ -158,6 +159,29 @@ public:
                           uint32_t height,
                           int32_t offsetX = 0,
                           int32_t offsetY = 0);
+
+    /**
+     * \brief Push constants to the pipeline
+     *
+     * \param pipelineLayout The pipeline layout
+     * \param stageFlags The stage flags
+     * \param offset The offset
+     * \param size The size
+     * \param pValues The values
+     */
+    void pushConstants(VkPipelineLayout pipelineLayout,
+                       VkShaderStageFlags stageFlags,
+                       uint32_t offset,
+                       uint32_t size,
+                       void const* pValues);
+
+    void beginRenderPass(VkRenderPass renderPass,
+                         VkFramebuffer framebuffer,
+                         VkExtent2D extent,
+                         VkClearValue clearColor,
+                         VkSubpassContents contents);
+
+    void endRenderPass();
 
 private:
     VkCommandBuffer g_commandBuffer;

--- a/includes/FastEngine/vulkan/C_commandBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_commandBuffer.hpp
@@ -175,13 +175,61 @@ public:
                        uint32_t size,
                        void const* pValues);
 
+    /**
+     * \brief Begin a render pass
+     *
+     * \param renderPass The render pass
+     * \param framebuffer The framebuffer
+     * \param extent The extent
+     * \param clearColor The clear color
+     * \param contents The subpass contents
+     */
     void beginRenderPass(VkRenderPass renderPass,
                          VkFramebuffer framebuffer,
                          VkExtent2D extent,
                          VkClearValue clearColor,
                          VkSubpassContents contents);
 
+    /**
+     * \brief End a render pass
+     *
+     * \warning You should call this function only if you have called beginRenderPass before
+     */
     void endRenderPass();
+
+    /**
+     * \brief Bind descriptor sets without dynamic parameters
+     *
+     * \param pipelineLayout The pipeline layout
+     * \param pipelineBindPoint The pipeline bind point
+     * \param descriptorSet The descriptor set
+     * \param descriptorCount The descriptor count
+     * \param firstSet The first set
+     */
+    void bindDescriptorSets(VkPipelineLayout pipelineLayout,
+                            VkPipelineBindPoint pipelineBindPoint,
+                            VkDescriptorSet const* descriptorSet,
+                            uint32_t descriptorCount,
+                            uint32_t firstSet);
+
+    /**
+     * \brief Bind descriptor sets with dynamic parameters
+     *
+     * \param pipelineLayout The pipeline layout
+     * \param pipelineBindPoint The pipeline bind point
+     * \param descriptorSet The descriptor set
+     * \param descriptorCount The descriptor count
+     * \param dynamicOffsetCount The dynamic offset count
+     * \param pDynamicOffsets The dynamic offsets
+     * \param firstSet The first set
+     */
+    void bindDescriptorSets(VkPipelineLayout pipelineLayout,
+                            VkPipelineBindPoint pipelineBindPoint,
+                            VkDescriptorSet const* descriptorSet,
+                            uint32_t descriptorCount,
+                            uint32_t dynamicOffsetCount,
+                            uint32_t const* pDynamicOffsets,
+                            uint32_t firstSet);
 
 private:
     VkCommandBuffer g_commandBuffer;

--- a/includes/FastEngine/vulkan/C_commandBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_commandBuffer.hpp
@@ -231,6 +231,80 @@ public:
                             uint32_t const* pDynamicOffsets,
                             uint32_t firstSet);
 
+    /**
+     * \brief Bind a pipeline
+     *
+     * \param pipelineBindPoint The pipeline bind point
+     * \param pipeline The pipeline
+     */
+    void bindPipeline(VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
+
+    /**
+     * \brief Set the viewport dynamically
+     *
+     * \warning You should use this function only if the graphic pipeline has the dynamic viewport state
+     *
+     * \param firstViewport The first viewport
+     * \param viewportCount The viewport count
+     * \param pViewports The viewports
+     */
+    void setViewport(uint32_t firstViewport, uint32_t viewportCount, VkViewport const* pViewports);
+    /**
+     * \brief Set the scissor dynamically
+     *
+     * \warning You should use this function only if the graphic pipeline has the dynamic scissor state
+     *
+     * \param firstScissor The first scissor
+     * \param scissorCount The scissor count
+     * \param pScissors The scissors
+     */
+    void setScissor(uint32_t firstScissor, uint32_t scissorCount, VkRect2D const* pScissors);
+
+    /**
+     * \brief Bind vertex buffers
+     *
+     * \param firstBinding The first binding
+     * \param bindingCount The binding count
+     * \param pBuffers The buffers
+     * \param pOffsets The offsets
+     */
+    void bindVertexBuffers(uint32_t firstBinding,
+                           uint32_t bindingCount,
+                           VkBuffer const* pBuffers,
+                           VkDeviceSize const* pOffsets);
+    /**
+     * \brief Bind an index buffer
+     *
+     * \param buffer The buffer
+     * \param offset The offset
+     * \param indexType The index type
+     */
+    void bindIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType indexType);
+
+    /**
+     * \brief Draw
+     *
+     * \param vertexCount The vertex count
+     * \param instanceCount The instance count
+     * \param firstVertex The first vertex
+     * \param firstInstance The first instance
+     */
+    void draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
+    /**
+     * \brief Draw indexed
+     *
+     * \param indexCount The index count
+     * \param instanceCount The instance count
+     * \param firstIndex The first index
+     * \param vertexOffset The vertex offset
+     * \param firstInstance The first instance
+     */
+    void drawIndexed(uint32_t indexCount,
+                     uint32_t instanceCount,
+                     uint32_t firstIndex,
+                     int32_t vertexOffset,
+                     uint32_t firstInstance);
+
 private:
     VkCommandBuffer g_commandBuffer;
     VkCommandPool g_commandPool;

--- a/includes/FastEngine/vulkan/C_commandBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_commandBuffer.hpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Guillaume Guillet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FGE_VULKAN_C_COMMANDBUFFER_HPP_INCLUDED
+#define _FGE_VULKAN_C_COMMANDBUFFER_HPP_INCLUDED
+
+#include "FastEngine/fge_extern.hpp"
+#include "FastEngine/vulkan/C_contextAware.hpp"
+#include "FastEngine/vulkan/vulkanGlobal.hpp"
+#include <utility>
+
+namespace fge::vulkan
+{
+
+/**
+ * \class CommandBuffer
+ * \brief Vulkan command buffer wrapper
+ * \ingroup vulkan
+ */
+class FGE_API CommandBuffer : public ContextAware
+{
+public:
+    enum class SubmitTypes
+    {
+        DIRECT_EXECUTION,
+        INDIRECT_EXECUTION,
+        INDIRECT_ISOLATED_EXECUTION
+    };
+
+    enum class RenderPassScopes
+    {
+        INSIDE,
+        OUTSIDE,
+        BOTH
+    };
+
+    enum SupportedQueueTypes : uint32_t
+    {
+        SUPPORTED_QUEUE_GRAPHICS = 1 << 0,
+        SUPPORTED_QUEUE_COMPUTE = 1 << 1,
+        SUPPORTED_QUEUE_TRANSFER = 1 << 2,
+
+        SUPPORTED_QUEUE_ALL = SUPPORTED_QUEUE_GRAPHICS | SUPPORTED_QUEUE_COMPUTE | SUPPORTED_QUEUE_TRANSFER
+    };
+    using SupportedQueueTypes_t = std::underlying_type_t<SupportedQueueTypes>;
+
+    CommandBuffer(Context const& context, VkCommandBufferLevel level, SubmitTypes type, VkCommandPool commandPool);
+    CommandBuffer(CommandBuffer const& r) = delete;
+    CommandBuffer(CommandBuffer&& r) noexcept = delete;
+    ~CommandBuffer() override;
+
+    CommandBuffer& operator=(CommandBuffer const& r) = delete;
+    CommandBuffer& operator=(CommandBuffer&& r) noexcept = delete;
+
+    void create(VkCommandBufferLevel level, SubmitTypes type, VkCommandPool commandPool);
+    void destroy() final;
+    [[nodiscard]] std::pair<VkCommandBuffer, VkCommandPool> release();
+
+    void reset();
+    void begin(VkCommandBufferUsageFlags flags);
+    void end();
+
+    [[nodiscard]] SubmitTypes getSubmitType() const;
+    [[nodiscard]] VkCommandBuffer get() const;
+    [[nodiscard]] VkCommandPool getPool() const;
+    [[nodiscard]] VkCommandBufferLevel getLevel() const;
+    [[nodiscard]] RenderPassScopes getRenderPassScope() const;
+    [[nodiscard]] SupportedQueueTypes_t getSupportedQueues() const;
+    [[nodiscard]] bool isEnded() const;
+
+    /**
+     * \brief Copy a buffer to another
+     *
+     * Fill a command buffer with a copy command in order to copy a buffer to another.
+     *
+     * \param srcBuffer The source buffer
+     * \param dstBuffer The destination buffer
+     * \param size The size of the buffer to copy
+     */
+    void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size);
+    /**
+     * \brief Transition an image layout
+     *
+     * Fill a command buffer with a transition command in order to transition an image layout.
+     *
+     * \param image The image
+     * \param format The format of the image
+     * \param oldLayout The old layout
+     * \param newLayout The new layout
+     * \param mipLevels The number of mip the image have
+     */
+    void transitionImageLayout(VkImage image,
+                               VkFormat format,
+                               VkImageLayout oldLayout,
+                               VkImageLayout newLayout,
+                               uint32_t mipLevels);
+    /**
+     * \brief Copy a buffer to an image
+     *
+     * Fill a command buffer with a copy command in order to copy a buffer to an image.
+     *
+     * \param buffer The buffer
+     * \param image The image
+     * \param width Width of the image
+     * \param height Height of the image
+     * \param offsetX An offset on the X axis
+     * \param offsetY An offset on the Y axis
+     */
+    void copyBufferToImage(VkBuffer buffer,
+                           VkImage image,
+                           uint32_t width,
+                           uint32_t height,
+                           int32_t offsetX = 0,
+                           int32_t offsetY = 0);
+    /**
+     * \brief Copy an image to a buffer
+     *
+     * Fill a command buffer with a copy command in order to copy an image to a buffer.
+     *
+     * \param image The image
+     * \param buffer The buffer
+     * \param width The width of the image
+     * \param height The height of the image
+     */
+    void copyImageToBuffer(VkImage image, VkBuffer buffer, uint32_t width, uint32_t height);
+    /**
+     * \brief Copy an image to another image
+     *
+     * Fill a command buffer with a copy command in order to copy an image to another image.
+     *
+     * \param srcImage The source image
+     * \param dstImage The destination image
+     * \param width The width of the image
+     * \param height The height of the image
+     * \param offsetX An offset on the X axis
+     * \param offsetY An offset on the Y axis
+     */
+    void copyImageToImage(VkImage srcImage,
+                          VkImage dstImage,
+                          uint32_t width,
+                          uint32_t height,
+                          int32_t offsetX = 0,
+                          int32_t offsetY = 0);
+
+private:
+    SubmitTypes g_type;
+    VkCommandBuffer g_commandBuffer;
+    VkCommandPool g_commandPool;
+    VkCommandBufferLevel g_level;
+    RenderPassScopes g_renderPassScope;
+    SupportedQueueTypes_t g_queueType;
+    bool g_isEnded;
+};
+
+} // namespace fge::vulkan
+
+#endif //_FGE_VULKAN_C_COMMANDBUFFER_HPP_INCLUDED

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -125,22 +125,22 @@ public:
     bool submitCommands(SubmitableCommandBuffer&& buffer) const;
 
     /**
-     * \brief Retrieve the semaphore that is signaled when the outside render scope command buffer have finished executing
+     * \brief Retrieve the semaphore that is signaled when all indirect command buffers have finished executing
      *
-     * This can return VK_NULL_HANDLE if the command buffer doesn't have any command to execute.
+     * This can return VK_NULL_HANDLE if there is no command buffers to execute.
      *
      * \see submit()
      *
      * \return The semaphore
      */
-    [[nodiscard]] VkSemaphore getOutsideRenderScopeSemaphore() const;
+    [[nodiscard]] VkSemaphore getIndirectSemaphore() const;
     /**
      * \brief Submit Context command buffers
      *
-     * outsideRenderScopeCommandBuffers are submitted with a semaphore that is signaled when the command buffers have
+     * Indirect CommandBuffers are submitted with a semaphore that is signaled when the all of them have
      * finished executing.
      *
-     * The semaphore should be retrieved with getOutsideRenderScopeSemaphore() and you must wait for it to be
+     * The semaphore should be retrieved with getIndirectSemaphore() and you must wait for it to be
      * signaled before rendering commands as this buffer generally contain some buffer transfer operations.
      *
      * This also increment the internal current frame counter.

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -357,8 +357,7 @@ private:
     mutable std::vector<VkCommandBuffer> g_graphicsSubmitableCommandBuffers;
 
     std::array<VkSemaphore, FGE_MAX_FRAMES_IN_FLIGHT> g_indirectFinishedSemaphores{};
-    mutable std::array<std::vector<SubmitableCommandBuffer>, FGE_MAX_FRAMES_IN_FLIGHT>
-            g_indirectSubmitableCommandBuffers{};
+    mutable std::array<std::vector<CommandBuffer>, FGE_MAX_FRAMES_IN_FLIGHT> g_indirectSubmitableCommandBuffers{};
     mutable std::array<ReusableCommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT>
             g_indirectOutsideRenderScopeGraphicsSubmitableCommandBuffers{};
 

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <vector>
 
+#include "FastEngine/vulkan/C_commandBuffer.hpp"
 #include "FastEngine/vulkan/C_descriptorPool.hpp"
 #include "FastEngine/vulkan/C_descriptorSetLayout.hpp"
 #include "FastEngine/vulkan/C_garbageCollector.hpp"
@@ -54,6 +55,26 @@ namespace fge::vulkan
 class FGE_API Context
 {
 public:
+    enum class SubmitTypes
+    {
+        DIRECT_WAIT_EXECUTION, ///< The command buffer is submitted directly to the queue and vkQueueWaitIdle is called
+        INDIRECT_EXECUTION ///< The command buffer is transferred to a queue in order to be submitted later and will always be executed before the rendering
+    };
+    class SubmitableCommandBuffer : public CommandBuffer
+    {
+    public:
+        using CommandBuffer::CommandBuffer;
+
+        [[nodiscard]] inline SubmitTypes getSubmitType() const { return g_submitType; }
+
+    private:
+        inline void setSubmitType(SubmitTypes type) { this->g_submitType = type; }
+
+        SubmitTypes g_submitType;
+
+        friend class Context;
+    };
+
     Context();
     Context(Context const& r) = delete;
     Context(Context&& r) noexcept = delete;
@@ -64,50 +85,44 @@ public:
 
     void destroy();
 
-    enum class SingleTimeCommandTypes
-    {
-        DIRECT_EXECUTION,
-        INDIRECT_OUTSIDE_RENDER_SCOPE_EXECUTION
-    };
-    struct SingleTimeCommand
-    {
-        SingleTimeCommandTypes _type;
-        VkCommandBuffer _commandBuffer;
-    };
-
     /**
-     * \brief Begin a single time command
+     * \brief Begin commands
      *
      * This return a command buffer that is ready to be used.
      *
-     * The DIRECT_EXECUTION type is used to execute a command buffer directly, this implies
+     * The DIRECT_WAIT_EXECUTION type is used to execute a command buffer directly, this implies
      * create the buffer,
      * submit the buffer,
-     * and waiting for all queue operations to be finished.
+     * and waiting for the coresponding queue operations to be finished.
      * This is not ideal for performance.
      *
-     * The INDIRECT_OUTSIDE_RENDER_SCOPE_EXECUTION type is used to execute your commands inside
-     * a reusable command buffer that is submitted to the graphics queue at the same time as a render command buffer
-     * in a RenderScreen. This is ideal for performance like copying staging buffers to device local buffers.
-     * 
-     * This is also synced with a semaphore that is signaled when the command buffer have finished executing so this
-     * assure that every commands are finished before rendering.
+     * The INDIRECT_EXECUTION type will create a command buffer that will be submitted later and
+     * executed with a semaphore that is signaled after every commands is done so this assure
+     * that every commands are finished before graphics commands.
+     * This is ideal for performance like copying staging buffers to device local buffers.
      *
-     * All this commands must be executed outside a render scope.
+     * On certain cases, a reusable command buffer is returned in order to optimize command buffer creation/destruction.
+     * Current case is when the command buffer is used outside a render scope and the graphics queue is wanted.
      *
-     * \warning This function must be pared with endSingleTimeCommands()
+     * \warning This function must be pared with submitCommands().
+     * CommandBuffer::begin(), CommandBuffer::end() and CommandBuffer::reset() should not be called.
      *
-     * \return The command buffer
+     * \param type The submit type of the command buffer
+     * \param wantedRenderPassScope The wanted render pass scope (for optimization purposes)
+     * \param wantedQueue The wanted queue (for optimization purposes)
+     * \return A submitable command buffer
      */
-    [[nodiscard]] SingleTimeCommand beginSingleTimeCommands(SingleTimeCommandTypes type) const;
+    [[nodiscard]] SubmitableCommandBuffer beginCommands(SubmitTypes type,
+                                                        CommandBuffer::RenderPassScopes wantedRenderPassScope,
+                                                        CommandBuffer::SupportedQueueTypes_t wantedQueue) const;
     /**
-     * \brief End a single time command
+     * \brief Submit commands
      *
-     * If the command type is DIRECT_EXECUTION, the command is queued to the graphics queue and is destroyed.
+     * \see beginCommands()
      *
-     * \param command The command to end
+     * \param buffer The command buffer to submit
      */
-    void endSingleTimeCommands(SingleTimeCommand command) const;
+    bool submitCommands(SubmitableCommandBuffer&& buffer) const;
 
     /**
      * \brief Retrieve the semaphore that is signaled when the outside render scope command buffer have finished executing
@@ -203,80 +218,6 @@ public:
                                         uint32_t commandBufferCount) const;
 
     /**
-     * \brief Copy a buffer to another
-     *
-     * Fill a command buffer with a copy command in order to copy a buffer to another.
-     *
-     * \param srcBuffer The source buffer
-     * \param dstBuffer The destination buffer
-     * \param size The size of the buffer to copy
-     */
-    void copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size) const;
-    /**
-     * \brief Transition an image layout
-     *
-     * Fill a command buffer with a transition command in order to transition an image layout.
-     *
-     * \param image The image
-     * \param format The format of the image
-     * \param oldLayout The old layout
-     * \param newLayout The new layout
-     * \param mipLevels The number of mip the image have
-     */
-    void transitionImageLayout(VkImage image,
-                               VkFormat format,
-                               VkImageLayout oldLayout,
-                               VkImageLayout newLayout,
-                               uint32_t mipLevels) const;
-    /**
-     * \brief Copy a buffer to an image
-     *
-     * Fill a command buffer with a copy command in order to copy a buffer to an image.
-     *
-     * \param buffer The buffer
-     * \param image The image
-     * \param width Width of the image
-     * \param height Height of the image
-     * \param offsetX An offset on the X axis
-     * \param offsetY An offset on the Y axis
-     */
-    void copyBufferToImage(VkBuffer buffer,
-                           VkImage image,
-                           uint32_t width,
-                           uint32_t height,
-                           int32_t offsetX = 0,
-                           int32_t offsetY = 0) const;
-    /**
-     * \brief Copy an image to a buffer
-     *
-     * Fill a command buffer with a copy command in order to copy an image to a buffer.
-     *
-     * \param image The image
-     * \param buffer The buffer
-     * \param width The width of the image
-     * \param height The height of the image
-     */
-    void copyImageToBuffer(VkImage image, VkBuffer buffer, uint32_t width, uint32_t height) const;
-    /**
-     * \brief Copy an image to another image
-     *
-     * Fill a command buffer with a copy command in order to copy an image to another image.
-     *
-     * \param srcImage The source image
-     * \param dstImage The destination image
-     * \param width The width of the image
-     * \param height The height of the image
-     * \param offsetX An offset on the X axis
-     * \param offsetY An offset on the Y axis
-     */
-    void copyImageToImage(VkImage srcImage,
-                          VkImage dstImage,
-                          uint32_t width,
-                          uint32_t height,
-                          int32_t offsetX = 0,
-                          int32_t offsetY = 0) const;
-
-    /**
      * \brief Retrieve or create a descriptor set layout from a key
      *
      * Certain objects need a custom descriptor set layout to be created for custom shaders.
@@ -353,7 +294,7 @@ public:
     /**
      * \brief Push a graphics command buffer to a list
      *
-     * This is used to keep track of executable command buffers that will be submitted to the graphics queue.
+     * This is used to keep track of submitable command buffers that will be submitted to the graphics queue.
      * This list must be cleared once the command buffers are submitted. Generally, this is done by a RenderScreen
      * when the RenderScreen::display() method is called.
      *
@@ -361,7 +302,7 @@ public:
      */
     void pushGraphicsCommandBuffer(VkCommandBuffer commandBuffer) const;
     /**
-     * \brief Retrieve the list of executable graphics command buffers
+     * \brief Retrieve the list of submitable graphics command buffers
      *
      * \see pushGraphicsCommandBuffer()
      *
@@ -369,13 +310,13 @@ public:
      */
     [[nodiscard]] std::vector<VkCommandBuffer> const& getGraphicsCommandBuffers() const;
     /**
-     * \brief Clear the list of executable graphics command buffers
+     * \brief Clear the list of submitable graphics command buffers
      *
      * \see pushGraphicsCommandBuffer()
      */
     void clearGraphicsCommandBuffers() const;
 
-    fge::vulkan::GarbageCollector _garbageCollector;
+    GarbageCollector _garbageCollector;
 
 private:
     void createCommandPool();
@@ -384,27 +325,43 @@ private:
     void createTransformDescriptorPool();
     void createSyncObjects();
 
+    struct ReusableCommandBuffer
+    {
+        constexpr ReusableCommandBuffer() = default;
+        constexpr ReusableCommandBuffer(VkCommandBuffer commandBuffer, bool isRecording) :
+                _commandBuffer(commandBuffer),
+                _isRecording(isRecording)
+        {}
+
+        VkCommandBuffer _commandBuffer{VK_NULL_HANDLE};
+        bool _isRecording{false};
+    };
+
     Instance g_instance;
     PhysicalDevice g_physicalDevice;
     LogicalDevice g_logicalDevice;
     Surface g_surface;
 
-    mutable std::map<std::string, fge::vulkan::DescriptorSetLayout, std::less<>> g_cacheLayouts;
+    mutable std::map<std::string, DescriptorSetLayout, std::less<>> g_cacheLayouts;
     DescriptorPool g_multiUseDescriptorPool;
 
-    fge::vulkan::DescriptorSetLayout g_textureLayout;
-    fge::vulkan::DescriptorSetLayout g_transformLayout;
+    DescriptorSetLayout g_textureLayout;
+    DescriptorSetLayout g_transformLayout;
     DescriptorPool g_textureDescriptorPool;
     DescriptorPool g_transformDescriptorPool;
 
     mutable VmaAllocator g_allocator;
 
-    std::array<VkCommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT> g_outsideRenderScopeCommandBuffers;
-    mutable std::array<bool, FGE_MAX_FRAMES_IN_FLIGHT> g_outsideRenderScopeCommandBuffersEmpty;
-    std::array<VkSemaphore, FGE_MAX_FRAMES_IN_FLIGHT> g_outsideRenderScopeFinishedSemaphores;
     mutable uint32_t g_currentFrame;
 
-    mutable std::vector<VkCommandBuffer> g_executableGraphicsCommandBuffers;
+    mutable std::vector<VkCommandBuffer> g_graphicsSubmitableCommandBuffers;
+
+    std::array<VkSemaphore, FGE_MAX_FRAMES_IN_FLIGHT> g_indirectFinishedSemaphores{};
+    mutable std::array<std::vector<SubmitableCommandBuffer>, FGE_MAX_FRAMES_IN_FLIGHT>
+            g_indirectSubmitableCommandBuffers{};
+    mutable std::array<ReusableCommandBuffer, FGE_MAX_FRAMES_IN_FLIGHT>
+            g_indirectOutsideRenderScopeGraphicsSubmitableCommandBuffers{};
+
     VkCommandPool g_graphicsCommandPool;
     bool g_isCreated;
 };

--- a/includes/FastEngine/vulkan/C_graphicPipeline.hpp
+++ b/includes/FastEngine/vulkan/C_graphicPipeline.hpp
@@ -85,12 +85,6 @@ public:
                                    uint32_t const* pDynamicOffsets,
                                    uint32_t firstSet = 0) const;
 
-    void pushConstants(VkCommandBuffer commandBuffer,
-                       VkShaderStageFlags stageFlags,
-                       uint32_t offset,
-                       uint32_t size,
-                       void const* pValues) const;
-
     [[nodiscard]] VkPipelineLayout getPipelineLayout() const;
     [[nodiscard]] VkPipeline getPipeline() const;
 

--- a/includes/FastEngine/vulkan/C_graphicPipeline.hpp
+++ b/includes/FastEngine/vulkan/C_graphicPipeline.hpp
@@ -31,6 +31,8 @@
 namespace fge::vulkan
 {
 
+class CommandBuffer;
+
 class FGE_API GraphicPipeline : public ContextAware
 {
 public:
@@ -66,11 +68,11 @@ public:
     void setPushConstantRanges(std::initializer_list<VkPushConstantRange> pushConstantRanges);
     [[nodiscard]] std::vector<VkPushConstantRange> const& getPushConstantRanges() const;
 
-    void recordCommandBuffer(VkCommandBuffer commandBuffer,
+    void recordCommandBuffer(CommandBuffer& commandBuffer,
                              Viewport const& viewport,
                              VertexBuffer const* vertexBuffer,
                              IndexBuffer const* indexBuffer) const;
-    void recordCommandBufferWithoutDraw(VkCommandBuffer commandBuffer,
+    void recordCommandBufferWithoutDraw(CommandBuffer& commandBuffer,
                                         Viewport const& viewport,
                                         VertexBuffer const* vertexBuffer,
                                         IndexBuffer const* indexBuffer) const;

--- a/includes/FastEngine/vulkan/C_graphicPipeline.hpp
+++ b/includes/FastEngine/vulkan/C_graphicPipeline.hpp
@@ -74,16 +74,6 @@ public:
                                         Viewport const& viewport,
                                         VertexBuffer const* vertexBuffer,
                                         IndexBuffer const* indexBuffer) const;
-    void bindDescriptorSets(VkCommandBuffer commandBuffer,
-                            VkDescriptorSet const* descriptorSet,
-                            uint32_t descriptorCount,
-                            uint32_t firstSet = 0) const;
-    void bindDynamicDescriptorSets(VkCommandBuffer commandBuffer,
-                                   VkDescriptorSet const* descriptorSet,
-                                   uint32_t descriptorCount,
-                                   uint32_t dynamicOffsetCount,
-                                   uint32_t const* pDynamicOffsets,
-                                   uint32_t firstSet = 0) const;
 
     [[nodiscard]] VkPipelineLayout getPipelineLayout() const;
     [[nodiscard]] VkPipeline getPipeline() const;

--- a/includes/FastEngine/vulkan/C_logicalDevice.hpp
+++ b/includes/FastEngine/vulkan/C_logicalDevice.hpp
@@ -49,12 +49,16 @@ public:
 
     [[nodiscard]] VkDevice getDevice() const;
     [[nodiscard]] VkQueue getGraphicQueue() const;
+    [[nodiscard]] VkQueue getComputeQueue() const;
+    [[nodiscard]] VkQueue getTransferQueue() const;
     [[nodiscard]] VkQueue getPresentQueue() const;
     [[nodiscard]] VkPhysicalDeviceFeatures getEnabledFeatures() const;
 
 private:
     VkDevice g_device;
     VkQueue g_graphicQueue;
+    VkQueue g_computeQueue;
+    VkQueue g_transferQueue;
     VkQueue g_presentQueue;
     VkPhysicalDeviceFeatures g_enabledFeatures;
 };

--- a/includes/FastEngine/vulkan/C_physicalDevice.hpp
+++ b/includes/FastEngine/vulkan/C_physicalDevice.hpp
@@ -37,12 +37,9 @@ public:
     struct QueueFamilyIndices
     {
         std::optional<uint32_t> _graphicsFamily;
+        std::optional<uint32_t> _computeFamily;
+        std::optional<uint32_t> _transferFamily;
         std::optional<uint32_t> _presentFamily;
-
-        [[nodiscard]] inline bool isComplete() const
-        {
-            return _graphicsFamily.has_value() && _presentFamily.has_value();
-        }
     };
     struct SwapChainSupportDetails
     {

--- a/includes/FastEngine/vulkan/C_vertexBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_vertexBuffer.hpp
@@ -31,6 +31,8 @@
 namespace fge::vulkan
 {
 
+class CommandBuffer;
+
 enum class BufferTypes
 {
     UNINITIALIZED,
@@ -59,7 +61,7 @@ public:
 
     void destroy() final;
 
-    void bind(VkCommandBuffer commandBuffer) const;
+    void bind(CommandBuffer& commandBuffer) const;
 
     [[nodiscard]] std::size_t getCount() const;
 
@@ -118,7 +120,7 @@ public:
 
     void destroy() final;
 
-    void bind(VkCommandBuffer commandBuffer) const;
+    void bind(CommandBuffer& commandBuffer) const;
 
     [[nodiscard]] std::size_t getCount() const;
 

--- a/includes/FastEngine/vulkan/C_viewport.hpp
+++ b/includes/FastEngine/vulkan/C_viewport.hpp
@@ -48,8 +48,6 @@ public:
 
     [[nodiscard]] VkViewport const& getViewport() const;
 
-    void cmdSetViewport(VkCommandBuffer commandBuffer) const;
-
 private:
     VkViewport g_viewport;
 };

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -42,13 +42,13 @@ class LogicalDevice;
 class PhysicalDevice;
 class Context;
 
-FGE_API extern std::vector<char const*> ValidationLayers;
+FGE_API extern std::vector<char const*> InstanceLayers;
 FGE_API extern std::vector<char const*> DeviceExtensions;
 
 FGE_API extern Context& GetActiveContext();
 FGE_API extern void SetActiveContext(Context& context);
 
-FGE_API bool CheckValidationLayerSupport(char const* layerName);
+FGE_API bool CheckInstanceLayerSupport(char const* layerName);
 
 FGE_API void CreateBuffer(Context const& context,
                           VkDeviceSize size,

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -298,7 +298,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
 
     graphicPipeline->updateIfNeeded(this->getRenderPass(), this->_g_forceGraphicPipelineUpdate);
 
-    auto commandBuffer = this->getCommandBuffer();
+    auto& commandBuffer = this->getCommandBuffer();
 
     if (states._resDescriptors.getCount() > 0)
     {
@@ -306,7 +306,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
         for (uint32_t i = 0; i < states._resDescriptors.getCount(); ++i)
         {
             auto descriptor = states._resDescriptors.getDescriptorSet(i)->get();
-            graphicPipeline->bindDescriptorSets(commandBuffer, &descriptor, 1, states._resDescriptors.getSet(i));
+            graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptor, 1, states._resDescriptors.getSet(i));
         }
     }
 
@@ -334,7 +334,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                         break;
                     }
                     auto descriptorSetTexture = textureImage->getDescriptorSet().get();
-                    graphicPipeline->bindDescriptorSets(commandBuffer, &descriptorSetTexture, 1,
+                    graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTexture, 1,
                                                         FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE + i);
                 }
             }
@@ -353,20 +353,21 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                 }
 
                 auto descriptorSetTexture = textureImage->getDescriptorSet().get();
-                graphicPipeline->bindDescriptorSets(commandBuffer, &descriptorSetTexture, 1,
+                graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTexture, 1,
                                                     FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
             }
         }
     }
 #endif //FGE_DEF_SERVER
 
-    graphicPipeline->recordCommandBufferWithoutDraw(commandBuffer, viewport, states._vertexBuffer, states._indexBuffer);
+    graphicPipeline->recordCommandBufferWithoutDraw(commandBuffer.get(), viewport, states._vertexBuffer,
+                                                    states._indexBuffer);
 
     //Binding default transform
     if (states._resTransform.get() != nullptr)
     {
         auto descriptorSetTransform = states._resTransform.get()->getDescriptorSet().get();
-        graphicPipeline->bindDescriptorSets(commandBuffer, &descriptorSetTransform, 1,
+        graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTransform, 1,
                                             FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TRANSFORM);
     }
 
@@ -401,7 +402,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                 }
 
                 auto descriptorSet = textureImage->getDescriptorSet().get();
-                graphicPipeline->bindDescriptorSets(commandBuffer, &descriptorSet, 1,
+                graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSet, 1,
                                                     FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
             }
         }
@@ -413,7 +414,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
             uint32_t const dynamicOffset = states._resInstances.getDynamicBufferSizes(i) * iInstance +
                                            states._resInstances.getDynamicBufferOffsets(i);
             auto descriptorSet = states._resInstances.getDynamicDescriptors(i)->get();
-            graphicPipeline->bindDynamicDescriptorSets(commandBuffer, &descriptorSet, 1, 1, &dynamicOffset,
+            graphicPipeline->bindDynamicDescriptorSets(commandBuffer.get(), &descriptorSet, 1, 1, &dynamicOffset,
                                                        states._resInstances.getDynamicSets(i));
         }
 
@@ -427,16 +428,16 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
         {
             if (states._resInstances.getIndirectBuffer() != VK_NULL_HANDLE)
             { //Indirect draw
-                vkCmdDrawIndirect(commandBuffer, states._resInstances.getIndirectBuffer(), 0,
+                vkCmdDrawIndirect(commandBuffer.get(), states._resInstances.getIndirectBuffer(), 0,
                                   states._resInstances.getInstancesCount(), sizeof(VkDrawIndirectCommand));
             }
             else
             {
-                vkCmdDraw(commandBuffer, vertexCount, states._resInstances.getInstancesCount(), vertexOffset, 0);
+                vkCmdDraw(commandBuffer.get(), vertexCount, states._resInstances.getInstancesCount(), vertexOffset, 0);
             }
             break;
         }
-        vkCmdDraw(commandBuffer, vertexCount, 1, vertexOffset, iInstance);
+        vkCmdDraw(commandBuffer.get(), vertexCount, 1, vertexOffset, iInstance);
     }
 }
 

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -306,7 +306,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
         for (uint32_t i = 0; i < states._resDescriptors.getCount(); ++i)
         {
             auto descriptor = states._resDescriptors.getDescriptorSet(i)->get();
-            graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptor, 1, states._resDescriptors.getSet(i));
+            commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                             &descriptor, 1, states._resDescriptors.getSet(i));
         }
     }
 
@@ -334,8 +335,9 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                         break;
                     }
                     auto descriptorSetTexture = textureImage->getDescriptorSet().get();
-                    graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTexture, 1,
-                                                        FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE + i);
+                    commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(),
+                                                     VK_PIPELINE_BIND_POINT_GRAPHICS, &descriptorSetTexture, 1,
+                                                     FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE + i);
                 }
             }
             else
@@ -353,8 +355,9 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                 }
 
                 auto descriptorSetTexture = textureImage->getDescriptorSet().get();
-                graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTexture, 1,
-                                                    FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
+                commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                 &descriptorSetTexture, 1,
+                                                 FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
             }
         }
     }
@@ -367,8 +370,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
     if (states._resTransform.get() != nullptr)
     {
         auto descriptorSetTransform = states._resTransform.get()->getDescriptorSet().get();
-        graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSetTransform, 1,
-                                            FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TRANSFORM);
+        commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                         &descriptorSetTransform, 1, FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TRANSFORM);
     }
 
     //Check instances
@@ -402,8 +405,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
                 }
 
                 auto descriptorSet = textureImage->getDescriptorSet().get();
-                graphicPipeline->bindDescriptorSets(commandBuffer.get(), &descriptorSet, 1,
-                                                    FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
+                commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                 &descriptorSet, 1, FGE_RENDERTARGET_DEFAULT_DESCRIPTOR_SET_TEXTURE);
             }
         }
 #endif //FGE_DEF_SERVER
@@ -414,8 +417,8 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
             uint32_t const dynamicOffset = states._resInstances.getDynamicBufferSizes(i) * iInstance +
                                            states._resInstances.getDynamicBufferOffsets(i);
             auto descriptorSet = states._resInstances.getDynamicDescriptors(i)->get();
-            graphicPipeline->bindDynamicDescriptorSets(commandBuffer.get(), &descriptorSet, 1, 1, &dynamicOffset,
-                                                       states._resInstances.getDynamicSets(i));
+            commandBuffer.bindDescriptorSets(graphicPipeline->getPipelineLayout(), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                             &descriptorSet, 1, 1, &dynamicOffset, 0);
         }
 
         uint32_t const vertexCount = states._resInstances.getVertexCount() == 0 ? states._vertexBuffer->getCount()

--- a/sources/graphic/C_renderTarget.cpp
+++ b/sources/graphic/C_renderTarget.cpp
@@ -363,8 +363,7 @@ void RenderTarget::draw(fge::RenderStates const& states, fge::vulkan::GraphicPip
     }
 #endif //FGE_DEF_SERVER
 
-    graphicPipeline->recordCommandBufferWithoutDraw(commandBuffer.get(), viewport, states._vertexBuffer,
-                                                    states._indexBuffer);
+    graphicPipeline->recordCommandBufferWithoutDraw(commandBuffer, viewport, states._vertexBuffer, states._indexBuffer);
 
     //Binding default transform
     if (states._resTransform.get() != nullptr)

--- a/sources/graphic/C_renderWindow.cpp
+++ b/sources/graphic/C_renderWindow.cpp
@@ -292,7 +292,6 @@ void RenderWindow::recreateSwapChain()
     this->g_swapChainFramebuffers.clear();
 
     vkDestroyRenderPass(this->getContext().getLogicalDevice().getDevice(), this->g_renderPass, nullptr);
-    this->g_swapChain.destroy();
 
     this->g_swapChain.create(this->getContext().getSurface().getWindow(), this->getContext().getLogicalDevice(),
                              this->getContext().getPhysicalDevice(), this->getContext().getSurface(),

--- a/sources/graphic/C_renderWindow.cpp
+++ b/sources/graphic/C_renderWindow.cpp
@@ -162,7 +162,7 @@ void RenderWindow::display(uint32_t imageIndex)
     VkSubmitInfo submitInfo{};
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-    auto contextSemaphore = this->getContext().getOutsideRenderScopeSemaphore();
+    auto contextSemaphore = this->getContext().getIndirectSemaphore();
 
     VkSemaphore waitSemaphores[] = {this->g_imageAvailableSemaphores[this->g_currentFrame], contextSemaphore};
     VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,

--- a/sources/graphic/C_renderWindow.cpp
+++ b/sources/graphic/C_renderWindow.cpp
@@ -43,7 +43,7 @@ int ResizeCallback(void* userdata, SDL_Event* event)
 
 RenderWindow::RenderWindow(fge::vulkan::Context const& context) :
         RenderTarget(context),
-        g_commandBuffers({VK_NULL_HANDLE}),
+        g_commandBuffers({context}),
         g_imageAvailableSemaphores({VK_NULL_HANDLE}),
         g_renderFinishedSemaphores({VK_NULL_HANDLE}),
         g_inFlightFences({VK_NULL_HANDLE})
@@ -72,10 +72,9 @@ void RenderWindow::destroy()
             vkDestroySemaphore(logicalDevice, this->g_imageAvailableSemaphores[i], nullptr);
             vkDestroySemaphore(logicalDevice, this->g_renderFinishedSemaphores[i], nullptr);
             vkDestroyFence(logicalDevice, this->g_inFlightFences[i], nullptr);
+            this->g_commandBuffers[i].destroy();
         }
 
-        vkFreeCommandBuffers(logicalDevice, this->getContext().getGraphicsCommandPool(), FGE_MAX_FRAMES_IN_FLIGHT,
-                             this->g_commandBuffers.data());
         for (auto framebuffer: this->g_swapChainFramebuffers)
         {
             vkDestroyFramebuffer(logicalDevice, framebuffer, nullptr);
@@ -111,53 +110,33 @@ uint32_t RenderWindow::prepareNextFrame([[maybe_unused]] VkCommandBufferInherita
     // Only reset the fence if we are submitting work
     vkResetFences(this->getContext().getLogicalDevice().getDevice(), 1, &this->g_inFlightFences[this->g_currentFrame]);
 
-    vkResetCommandBuffer(this->g_commandBuffers[this->g_currentFrame], 0);
-
-    VkCommandBufferBeginInfo beginInfo{};
-    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    beginInfo.flags = 0;                  // Optional
-    beginInfo.pInheritanceInfo = nullptr; // Optional
-
-    if (vkBeginCommandBuffer(this->g_commandBuffers[this->g_currentFrame], &beginInfo) != VK_SUCCESS)
-    {
-        throw fge::Exception("failed to begin recording command buffer!");
-    }
+    this->g_commandBuffers[this->g_currentFrame].reset();
+    this->g_commandBuffers[this->g_currentFrame].begin(0);
 
     return imageIndex;
 }
 void RenderWindow::beginRenderPass(uint32_t imageIndex)
 {
-    VkRenderPassBeginInfo renderPassInfo{};
-    renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-    renderPassInfo.renderPass = this->g_renderPass;
-    renderPassInfo.framebuffer = this->g_swapChainFramebuffers[imageIndex];
-
-    renderPassInfo.renderArea.offset = {0, 0};
-    renderPassInfo.renderArea.extent = this->g_swapChain.getSwapChainExtent();
-
     VkClearValue const clearColor = {.color = this->_g_clearColor};
-    renderPassInfo.clearValueCount = 1;
-    renderPassInfo.pClearValues = &clearColor;
 
-    vkCmdBeginRenderPass(this->g_commandBuffers[this->g_currentFrame], &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    this->g_commandBuffers[this->g_currentFrame].beginRenderPass(
+            this->g_renderPass, this->g_swapChainFramebuffers[imageIndex], this->g_swapChain.getSwapChainExtent(),
+            clearColor, VK_SUBPASS_CONTENTS_INLINE);
 }
 void RenderWindow::endRenderPass()
 {
-    vkCmdEndRenderPass(this->g_commandBuffers[this->g_currentFrame]);
+    this->g_commandBuffers[this->g_currentFrame].endRenderPass();
 
     if (this->_g_forceGraphicPipelineUpdate)
     {
         this->_g_forceGraphicPipelineUpdate = false;
     }
 
-    if (vkEndCommandBuffer(this->g_commandBuffers[this->g_currentFrame]) != VK_SUCCESS)
-    {
-        throw fge::Exception("failed to record command buffer!");
-    }
+    this->g_commandBuffers[this->g_currentFrame].end();
 }
 void RenderWindow::display(uint32_t imageIndex)
 {
-    this->getContext().pushGraphicsCommandBuffer(this->g_commandBuffers[this->g_currentFrame]);
+    this->getContext().pushGraphicsCommandBuffer(this->g_commandBuffers[this->g_currentFrame].get());
 
     VkSubmitInfo submitInfo{};
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -235,7 +214,7 @@ VkExtent2D RenderWindow::getExtent2D() const
 {
     return this->g_swapChain.getSwapChainExtent();
 }
-VkCommandBuffer RenderWindow::getCommandBuffer() const
+fge::vulkan::CommandBuffer& RenderWindow::getCommandBuffer() const
 {
     return this->g_commandBuffers[this->g_currentFrame];
 }
@@ -282,8 +261,10 @@ void RenderWindow::init()
     this->createFramebuffers();
 
     //create command buffers
-    this->getContext().allocateGraphicsCommandBuffers(VK_COMMAND_BUFFER_LEVEL_PRIMARY, this->g_commandBuffers.data(),
-                                                      this->g_commandBuffers.size());
+    for (auto& commandBuffer: this->g_commandBuffers)
+    {
+        commandBuffer.create(VK_COMMAND_BUFFER_LEVEL_PRIMARY, this->getContext().getGraphicsCommandPool());
+    }
 
     this->createSyncObjects();
 

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -248,8 +248,8 @@ FGE_OBJ_DRAW_BODY(ObjShape)
     copyStates._vertexBuffer = &this->g_vertices;
 
     glm::uint colorIndex = FGE_OBJSHAPE_INDEX_FILLCOLOR;
-    graphicPipeline->pushConstants(target.getCommandBuffer(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::uint),
-                                   &colorIndex);
+    target.getCommandBuffer().pushConstants(graphicPipeline->getPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT, 0,
+                                            sizeof(glm::uint), &colorIndex);
 
     copyStates._resInstances.setInstancesCount(this->g_instancesCount, true);
     uint32_t const sets[] = {1};
@@ -259,8 +259,8 @@ FGE_OBJ_DRAW_BODY(ObjShape)
 
     //Drawing outline
     colorIndex = FGE_OBJSHAPE_INDEX_OUTLINECOLOR;
-    graphicPipelineOutline->pushConstants(target.getCommandBuffer(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(glm::uint),
-                                          &colorIndex);
+    target.getCommandBuffer().pushConstants(graphicPipelineOutline->getPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT, 0,
+                                            sizeof(glm::uint), &colorIndex);
 
     copyStates._resTextures.set<std::nullptr_t>(nullptr, 0);
     copyStates._vertexBuffer = &this->g_outlineVertices;

--- a/sources/vulkan/C_commandBuffer.cpp
+++ b/sources/vulkan/C_commandBuffer.cpp
@@ -146,8 +146,8 @@ std::pair<VkCommandBuffer, VkCommandPool> CommandBuffer::release()
 {
     if (this->g_commandBuffer != VK_NULL_HANDLE)
     {
-        auto* buffer = this->g_commandBuffer;
-        auto* pool = this->g_commandPool;
+        auto buffer = this->g_commandBuffer;
+        auto pool = this->g_commandPool;
 
         this->g_commandBuffer = VK_NULL_HANDLE;
         this->g_commandPool = VK_NULL_HANDLE;

--- a/sources/vulkan/C_commandBuffer.cpp
+++ b/sources/vulkan/C_commandBuffer.cpp
@@ -576,4 +576,40 @@ void CommandBuffer::endRenderPass()
     ++this->g_recordedCommands;
 }
 
+void CommandBuffer::bindDescriptorSets(VkPipelineLayout pipelineLayout,
+                                       VkPipelineBindPoint pipelineBindPoint,
+                                       VkDescriptorSet const* descriptorSet,
+                                       uint32_t descriptorCount,
+                                       uint32_t firstSet)
+{
+    this->bindDescriptorSets(pipelineLayout, pipelineBindPoint, descriptorSet, descriptorCount, 0, nullptr, firstSet);
+}
+
+void CommandBuffer::bindDescriptorSets(VkPipelineLayout pipelineLayout,
+                                       VkPipelineBindPoint pipelineBindPoint,
+                                       VkDescriptorSet const* descriptorSet,
+                                       uint32_t descriptorCount,
+                                       uint32_t dynamicOffsetCount,
+                                       uint32_t const* pDynamicOffsets,
+                                       uint32_t firstSet)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & (SUPPORTED_QUEUE_COMPUTE | SUPPORTED_QUEUE_GRAPHICS)) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdBindDescriptorSets(this->g_commandBuffer, pipelineBindPoint, pipelineLayout, firstSet, descriptorCount,
+                            descriptorSet, dynamicOffsetCount, pDynamicOffsets);
+    this->g_queueType &= SUPPORTED_QUEUE_COMPUTE | SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+
 } // namespace fge::vulkan

--- a/sources/vulkan/C_commandBuffer.cpp
+++ b/sources/vulkan/C_commandBuffer.cpp
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2024 Guillaume Guillet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FastEngine/vulkan/C_commandBuffer.hpp"
+#include "FastEngine/vulkan/C_context.hpp"
+
+namespace fge::vulkan
+{
+
+CommandBuffer::CommandBuffer(Context const& context,
+                             VkCommandBufferLevel level,
+                             SubmitTypes type,
+                             VkCommandPool commandPool) :
+        ContextAware(context),
+        g_type(type),
+        g_commandBuffer(VK_NULL_HANDLE),
+        g_commandPool(VK_NULL_HANDLE),
+        g_level(level),
+        g_renderPassScope(RenderPassScopes::BOTH),
+        g_queueType(SUPPORTED_QUEUE_ALL),
+        g_isEnded(false)
+{
+    this->create(level, type, commandPool);
+}
+CommandBuffer::~CommandBuffer()
+{
+    this->destroy();
+}
+
+void CommandBuffer::create(VkCommandBufferLevel level, SubmitTypes type, VkCommandPool commandPool)
+{
+    this->destroy();
+
+    this->g_level = level;
+    this->g_type = type;
+    this->g_commandPool = commandPool;
+
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.level = level;
+    allocInfo.commandPool = commandPool;
+    allocInfo.commandBufferCount = 1;
+
+    if (vkAllocateCommandBuffers(this->getContext().getLogicalDevice().getDevice(), &allocInfo,
+                                 &this->g_commandBuffer) != VK_SUCCESS)
+    {
+        throw fge::Exception("failed to allocate command buffer!");
+    }
+}
+void CommandBuffer::destroy()
+{
+    if (this->g_commandBuffer != VK_NULL_HANDLE)
+    {
+        vkFreeCommandBuffers(this->getContext().getLogicalDevice().getDevice(), this->g_commandPool, 1,
+                             &this->g_commandBuffer);
+        this->g_commandBuffer = VK_NULL_HANDLE;
+        this->g_commandPool = VK_NULL_HANDLE, this->g_queueType = SUPPORTED_QUEUE_ALL,
+        this->g_renderPassScope = RenderPassScopes::BOTH, this->g_isEnded = false;
+    }
+}
+std::pair<VkCommandBuffer, VkCommandPool> CommandBuffer::release()
+{
+    if (this->g_commandBuffer != VK_NULL_HANDLE)
+    {
+        auto* buffer = this->g_commandBuffer;
+        auto* pool = this->g_commandPool;
+
+        this->g_commandBuffer = VK_NULL_HANDLE;
+        this->g_commandPool = VK_NULL_HANDLE, this->g_queueType = SUPPORTED_QUEUE_ALL,
+        this->g_renderPassScope = RenderPassScopes::BOTH, this->g_isEnded = false;
+
+        return {buffer, pool};
+    }
+    return {VK_NULL_HANDLE, VK_NULL_HANDLE};
+}
+
+void CommandBuffer::reset()
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+
+    vkResetCommandBuffer(this->g_commandBuffer, 0);
+    this->g_queueType = SUPPORTED_QUEUE_ALL, this->g_renderPassScope = RenderPassScopes::BOTH, this->g_isEnded = false;
+}
+void CommandBuffer::begin(VkCommandBufferUsageFlags flags)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = flags;
+
+    vkBeginCommandBuffer(this->g_commandBuffer, &beginInfo);
+}
+void CommandBuffer::end()
+{
+    if (this->g_isEnded)
+    {
+        return;
+    }
+
+    vkEndCommandBuffer(this->g_commandBuffer);
+    this->g_isEnded = true;
+}
+
+CommandBuffer::SubmitTypes CommandBuffer::getSubmitType() const
+{
+    return this->g_type;
+}
+VkCommandBuffer CommandBuffer::get() const
+{
+    return this->g_commandBuffer;
+}
+VkCommandPool CommandBuffer::getPool() const
+{
+    return this->g_commandPool;
+}
+VkCommandBufferLevel CommandBuffer::getLevel() const
+{
+    return this->g_level;
+}
+CommandBuffer::RenderPassScopes CommandBuffer::getRenderPassScope() const
+{
+    return this->g_renderPassScope;
+}
+CommandBuffer::SupportedQueueTypes_t CommandBuffer::getSupportedQueues() const
+{
+    return this->g_queueType;
+}
+bool CommandBuffer::isEnded() const
+{
+    return this->g_isEnded;
+}
+
+void CommandBuffer::copyBuffer(VkBuffer srcBuffer, VkBuffer dstBuffer, VkDeviceSize size)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::INSIDE)
+    {
+        throw fge::Exception("Command executed inside a render pass !");
+    }
+
+    VkBufferCopy copyRegion{};
+    copyRegion.srcOffset = 0;
+    copyRegion.dstOffset = 0;
+    copyRegion.size = size;
+    vkCmdCopyBuffer(this->g_commandBuffer, srcBuffer, dstBuffer, 1, &copyRegion);
+
+    this->g_renderPassScope = RenderPassScopes::OUTSIDE;
+}
+
+void CommandBuffer::transitionImageLayout(VkImage image,
+                                          [[maybe_unused]] VkFormat format,
+                                          VkImageLayout oldLayout,
+                                          VkImageLayout newLayout,
+                                          uint32_t mipLevels)
+{ ///TODO: format
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = mipLevels;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+
+    VkPipelineStageFlags sourceStage{};
+    VkPipelineStageFlags destinationStage{};
+
+    if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+    {
+        barrier.srcAccessMask = 0;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+    {
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+    {
+        barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+    {
+        barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+    else if (oldLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && newLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+    {
+        barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+        sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    }
+    else
+    {
+        throw fge::Exception("unsupported layout transition!");
+    }
+
+    vkCmdPipelineBarrier(this->g_commandBuffer, sourceStage, destinationStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+void CommandBuffer::copyBufferToImage(VkBuffer buffer,
+                                      VkImage image,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      int32_t offsetX,
+                                      int32_t offsetY)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::INSIDE)
+    {
+        throw fge::Exception("Command executed inside a render pass !");
+    }
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+
+    region.imageOffset = {offsetX, offsetY, 0};
+    region.imageExtent = {width, height, 1};
+
+    vkCmdCopyBufferToImage(this->g_commandBuffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    this->g_renderPassScope = RenderPassScopes::OUTSIDE;
+}
+void CommandBuffer::copyImageToBuffer(VkImage image, VkBuffer buffer, uint32_t width, uint32_t height)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::INSIDE)
+    {
+        throw fge::Exception("Command executed inside a render pass !");
+    }
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+
+    region.imageOffset = {0, 0, 0};
+    region.imageExtent = {width, height, 1};
+
+    vkCmdCopyImageToBuffer(this->g_commandBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer, 1, &region);
+
+    this->g_renderPassScope = RenderPassScopes::OUTSIDE;
+}
+void CommandBuffer::copyImageToImage(VkImage srcImage,
+                                     VkImage dstImage,
+                                     uint32_t width,
+                                     uint32_t height,
+                                     int32_t offsetX,
+                                     int32_t offsetY)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::INSIDE)
+    {
+        throw fge::Exception("Command executed inside a render pass !");
+    }
+
+    VkImageCopy region{};
+    region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.srcSubresource.mipLevel = 0;
+    region.srcSubresource.baseArrayLayer = 0;
+    region.srcSubresource.layerCount = 1;
+    region.srcOffset = {offsetX, offsetY, 0};
+
+    region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.dstSubresource.mipLevel = 0;
+    region.dstSubresource.baseArrayLayer = 0;
+    region.dstSubresource.layerCount = 1;
+    region.dstOffset = {0, 0, 0};
+
+    region.extent.width = width;
+    region.extent.height = height;
+    region.extent.depth = 1;
+
+    vkCmdCopyImage(this->g_commandBuffer, srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage,
+                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    this->g_renderPassScope = RenderPassScopes::OUTSIDE;
+}
+
+} // namespace fge::vulkan

--- a/sources/vulkan/C_commandBuffer.cpp
+++ b/sources/vulkan/C_commandBuffer.cpp
@@ -612,4 +612,158 @@ void CommandBuffer::bindDescriptorSets(VkPipelineLayout pipelineLayout,
     ++this->g_recordedCommands;
 }
 
+void CommandBuffer::bindPipeline(VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & (SUPPORTED_QUEUE_COMPUTE | SUPPORTED_QUEUE_GRAPHICS)) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdBindPipeline(this->g_commandBuffer, pipelineBindPoint, pipeline);
+    this->g_queueType &= SUPPORTED_QUEUE_COMPUTE | SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+
+void CommandBuffer::setViewport(uint32_t firstViewport, uint32_t viewportCount, VkViewport const* pViewports)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdSetViewport(this->g_commandBuffer, firstViewport, viewportCount, pViewports);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+void CommandBuffer::setScissor(uint32_t firstScissor, uint32_t scissorCount, VkRect2D const* pScissors)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdSetScissor(this->g_commandBuffer, firstScissor, scissorCount, pScissors);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+
+void CommandBuffer::bindVertexBuffers(uint32_t firstBinding,
+                                      uint32_t bindingCount,
+                                      VkBuffer const* pBuffers,
+                                      VkDeviceSize const* pOffsets)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdBindVertexBuffers(this->g_commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+void CommandBuffer::bindIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType indexType)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdBindIndexBuffer(this->g_commandBuffer, buffer, offset, indexType);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    ++this->g_recordedCommands;
+}
+
+void CommandBuffer::draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::OUTSIDE)
+    {
+        throw fge::Exception("Command executed outside a render pass !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdDraw(this->g_commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    this->g_renderPassScope = RenderPassScopes::INSIDE;
+    ++this->g_recordedCommands;
+}
+void CommandBuffer::drawIndexed(uint32_t indexCount,
+                                uint32_t instanceCount,
+                                uint32_t firstIndex,
+                                int32_t vertexOffset,
+                                uint32_t firstInstance)
+{
+    if (this->g_commandBuffer == VK_NULL_HANDLE)
+    {
+        throw fge::Exception("CommandBuffer not created !");
+    }
+    if (this->g_isEnded)
+    {
+        throw fge::Exception("CommandBuffer already ended !");
+    }
+    if (this->g_renderPassScope == RenderPassScopes::OUTSIDE)
+    {
+        throw fge::Exception("Command executed outside a render pass !");
+    }
+    if ((this->g_queueType & SUPPORTED_QUEUE_GRAPHICS) == 0)
+    {
+        throw fge::Exception("Unsupported queue type for this command buffer !");
+    }
+
+    vkCmdDrawIndexed(this->g_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+    this->g_queueType &= SUPPORTED_QUEUE_GRAPHICS;
+    this->g_renderPassScope = RenderPassScopes::INSIDE;
+    ++this->g_recordedCommands;
+}
+
 } // namespace fge::vulkan

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -175,9 +175,10 @@ bool Context::submitCommands(SubmitableCommandBuffer&& buffer) const
     return true;
 }
 
-VkSemaphore Context::getOutsideRenderScopeSemaphore() const
+VkSemaphore Context::getIndirectSemaphore() const
 {
-    return this->g_indirectOutsideRenderScopeGraphicsSubmitableCommandBuffers[this->g_currentFrame]._isRecording
+    return this->g_indirectOutsideRenderScopeGraphicsSubmitableCommandBuffers[this->g_currentFrame]._isRecording ||
+                           !this->g_indirectSubmitableCommandBuffers[this->g_currentFrame].empty()
                    ? this->g_indirectFinishedSemaphores[this->g_currentFrame]
                    : VK_NULL_HANDLE;
 }

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -135,13 +135,11 @@ bool Context::submitCommands(SubmitableCommandBuffer&& buffer) const
         }
         else if ((buffer.getSupportedQueues() & CommandBuffer::SUPPORTED_QUEUE_COMPUTE) > 0)
         {
-            //TODO: queue = this->g_logicalDevice.getComputeQueue();
-            queue = VK_NULL_HANDLE;
+            queue = this->g_logicalDevice.getComputeQueue();
         }
         else if ((buffer.getSupportedQueues() & CommandBuffer::SUPPORTED_QUEUE_TRANSFER) > 0)
         {
-            //TODO: queue = this->g_logicalDevice.getTransferQueue();
-            queue = VK_NULL_HANDLE;
+            queue = this->g_logicalDevice.getTransferQueue();
         }
 
         if (queue == VK_NULL_HANDLE)

--- a/sources/vulkan/C_graphicPipeline.cpp
+++ b/sources/vulkan/C_graphicPipeline.cpp
@@ -369,15 +369,15 @@ std::vector<VkPushConstantRange> const& GraphicPipeline::getPushConstantRanges()
     return this->g_pushConstantRanges;
 }
 
-void GraphicPipeline::recordCommandBuffer(VkCommandBuffer commandBuffer,
+void GraphicPipeline::recordCommandBuffer(CommandBuffer& commandBuffer,
                                           Viewport const& viewport,
                                           VertexBuffer const* vertexBuffer,
                                           IndexBuffer const* indexBuffer) const
 {
-    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_graphicsPipeline);
+    commandBuffer.bindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_graphicsPipeline);
 
-    viewport.cmdSetViewport(commandBuffer);
-    vkCmdSetScissor(commandBuffer, 0, 1, &this->g_scissor);
+    commandBuffer.setViewport(0, 1, &viewport.getViewport());
+    commandBuffer.setScissor(0, 1, &this->g_scissor);
 
     if (vertexBuffer != nullptr && vertexBuffer->getType() != BufferTypes::UNINITIALIZED)
     {
@@ -385,27 +385,27 @@ void GraphicPipeline::recordCommandBuffer(VkCommandBuffer commandBuffer,
         if (indexBuffer != nullptr && indexBuffer->getType() != BufferTypes::UNINITIALIZED)
         {
             indexBuffer->bind(commandBuffer);
-            vkCmdDrawIndexed(commandBuffer, indexBuffer->getCount(), 1, 0, 0, 0);
+            commandBuffer.drawIndexed(indexBuffer->getCount(), 1, 0, 0, 0);
         }
         else
         {
-            vkCmdDraw(commandBuffer, vertexBuffer->getCount(), 1, 0, 0);
+            commandBuffer.draw(vertexBuffer->getCount(), 1, 0, 0);
         }
     }
     else
     {
-        vkCmdDraw(commandBuffer, this->g_defaultVertexCount, 1, 0, 0);
+        commandBuffer.draw(this->g_defaultVertexCount, 1, 0, 0);
     }
 }
-void GraphicPipeline::recordCommandBufferWithoutDraw(VkCommandBuffer commandBuffer,
+void GraphicPipeline::recordCommandBufferWithoutDraw(CommandBuffer& commandBuffer,
                                                      Viewport const& viewport,
                                                      VertexBuffer const* vertexBuffer,
                                                      IndexBuffer const* indexBuffer) const
 {
-    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_graphicsPipeline);
+    commandBuffer.bindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_graphicsPipeline);
 
-    viewport.cmdSetViewport(commandBuffer);
-    vkCmdSetScissor(commandBuffer, 0, 1, &this->g_scissor);
+    commandBuffer.setViewport(0, 1, &viewport.getViewport());
+    commandBuffer.setScissor(0, 1, &this->g_scissor);
 
     if (vertexBuffer != nullptr && vertexBuffer->getType() != BufferTypes::UNINITIALIZED)
     {

--- a/sources/vulkan/C_graphicPipeline.cpp
+++ b/sources/vulkan/C_graphicPipeline.cpp
@@ -245,6 +245,7 @@ void GraphicPipeline::setDescriptorSetLayouts(std::initializer_list<VkDescriptor
 {
     this->cleanPipelineLayout();
     this->g_descriptorSetLayouts = descriptorSetLayouts;
+    this->updatePipelineLayout();
     this->g_needUpdate = true;
 }
 std::vector<VkDescriptorSetLayout> const& GraphicPipeline::getDescriptorSetLayouts() const
@@ -360,6 +361,7 @@ void GraphicPipeline::setPushConstantRanges(std::initializer_list<VkPushConstant
 {
     this->cleanPipelineLayout();
     this->g_pushConstantRanges = pushConstantRanges;
+    this->updatePipelineLayout();
     this->g_needUpdate = true;
 }
 std::vector<VkPushConstantRange> const& GraphicPipeline::getPushConstantRanges() const
@@ -419,7 +421,6 @@ void GraphicPipeline::bindDescriptorSets(VkCommandBuffer commandBuffer,
                                          uint32_t descriptorCount,
                                          uint32_t firstSet) const
 {
-    this->updatePipelineLayout();
     vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_pipelineLayout, firstSet,
                             descriptorCount, descriptorSet, 0, nullptr);
 }
@@ -430,19 +431,8 @@ void GraphicPipeline::bindDynamicDescriptorSets(VkCommandBuffer commandBuffer,
                                                 uint32_t const* pDynamicOffsets,
                                                 uint32_t firstSet) const
 {
-    this->updatePipelineLayout();
     vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_pipelineLayout, firstSet,
                             descriptorCount, descriptorSet, dynamicOffsetCount, pDynamicOffsets);
-}
-
-void GraphicPipeline::pushConstants(VkCommandBuffer commandBuffer,
-                                    VkShaderStageFlags stageFlags,
-                                    uint32_t offset,
-                                    uint32_t size,
-                                    void const* pValues) const
-{
-    this->updatePipelineLayout();
-    vkCmdPushConstants(commandBuffer, this->g_pipelineLayout, stageFlags, offset, size, pValues);
 }
 
 VkPipelineLayout GraphicPipeline::getPipelineLayout() const

--- a/sources/vulkan/C_graphicPipeline.cpp
+++ b/sources/vulkan/C_graphicPipeline.cpp
@@ -416,24 +416,6 @@ void GraphicPipeline::recordCommandBufferWithoutDraw(VkCommandBuffer commandBuff
         }
     }
 }
-void GraphicPipeline::bindDescriptorSets(VkCommandBuffer commandBuffer,
-                                         VkDescriptorSet const* descriptorSet,
-                                         uint32_t descriptorCount,
-                                         uint32_t firstSet) const
-{
-    vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_pipelineLayout, firstSet,
-                            descriptorCount, descriptorSet, 0, nullptr);
-}
-void GraphicPipeline::bindDynamicDescriptorSets(VkCommandBuffer commandBuffer,
-                                                VkDescriptorSet const* descriptorSet,
-                                                uint32_t descriptorCount,
-                                                uint32_t dynamicOffsetCount,
-                                                uint32_t const* pDynamicOffsets,
-                                                uint32_t firstSet) const
-{
-    vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, this->g_pipelineLayout, firstSet,
-                            descriptorCount, descriptorSet, dynamicOffsetCount, pDynamicOffsets);
-}
 
 VkPipelineLayout GraphicPipeline::getPipelineLayout() const
 {

--- a/sources/vulkan/C_instance.cpp
+++ b/sources/vulkan/C_instance.cpp
@@ -57,22 +57,20 @@ void Instance::create(std::string applicationName, uint16_t versionMajor, uint16
     appInfo.engineVersion = VK_MAKE_API_VERSION(0, FGE_VERSION_MAJOR, FGE_VERSION_MINOR, FGE_VERSION_REVISION);
     appInfo.apiVersion = VK_API_VERSION_1_1;
 
-#ifdef FGE_ENABLE_VALIDATION_LAYERS
-    std::vector<char const*> validValidationLayers;
-    validValidationLayers.reserve(ValidationLayers.size());
+    std::vector<char const*> validInstanceLayers;
+    validInstanceLayers.reserve(InstanceLayers.size());
 
-    for (char const* layerName: ValidationLayers)
+    for (char const* layerName: InstanceLayers)
     {
-        if (!CheckValidationLayerSupport(layerName))
+        if (!CheckInstanceLayerSupport(layerName))
         {
             std::cout << "validation layer \"" << layerName << "\" requested, but not available (will be ignored) !\n";
         }
         else
         {
-            validValidationLayers.push_back(layerName);
+            validInstanceLayers.push_back(layerName);
         }
     }
-#endif
 
     uint32_t enabled_extension_count = 0;
     if (SDL_Vulkan_GetInstanceExtensions(nullptr, &enabled_extension_count, nullptr) == SDL_FALSE)
@@ -90,12 +88,8 @@ void Instance::create(std::string applicationName, uint16_t versionMajor, uint16
     createInfo.enabledExtensionCount = enabled_extension_count;
     createInfo.ppEnabledExtensionNames = reinterpret_cast<char const* const*>(extensions.data());
 
-#ifndef FGE_ENABLE_VALIDATION_LAYERS
-    createInfo.enabledLayerCount = 0;
-#else
-    createInfo.enabledLayerCount = static_cast<uint32_t>(validValidationLayers.size());
-    createInfo.ppEnabledLayerNames = validValidationLayers.data();
-#endif
+    createInfo.enabledLayerCount = static_cast<uint32_t>(validInstanceLayers.size());
+    createInfo.ppEnabledLayerNames = validInstanceLayers.empty() ? nullptr : validInstanceLayers.data();
 
     VkResult const result = vkCreateInstance(&createInfo, nullptr, &this->g_instance);
 

--- a/sources/vulkan/C_logicalDevice.cpp
+++ b/sources/vulkan/C_logicalDevice.cpp
@@ -19,6 +19,7 @@
 #include "FastEngine/vulkan/C_physicalDevice.hpp"
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include <cstring>
+#include <set>
 #include <vector>
 
 namespace fge::vulkan
@@ -47,7 +48,9 @@ void LogicalDevice::create(PhysicalDevice& physicalDevice, VkSurfaceKHR surface)
 {
     auto indices = physicalDevice.findQueueFamilies(surface);
 
-    std::vector<uint32_t> const uniqueQueueFamilies = {indices._graphicsFamily.value(), indices._presentFamily.value()};
+    std::set<uint32_t> uniqueQueueFamilies = {indices._graphicsFamily.value(), indices._computeFamily.value(),
+                                              indices._transferFamily.value(), indices._presentFamily.value()};
+
     std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
 
     float const queuePriority = 1.0f;
@@ -123,6 +126,8 @@ void LogicalDevice::create(PhysicalDevice& physicalDevice, VkSurfaceKHR surface)
     }
 
     vkGetDeviceQueue(this->g_device, indices._graphicsFamily.value(), 0, &this->g_graphicQueue);
+    vkGetDeviceQueue(this->g_device, indices._computeFamily.value(), 0, &this->g_computeQueue);
+    vkGetDeviceQueue(this->g_device, indices._transferFamily.value(), 0, &this->g_transferQueue);
     vkGetDeviceQueue(this->g_device, indices._presentFamily.value(), 0, &this->g_presentQueue);
 }
 void LogicalDevice::destroy()
@@ -143,6 +148,14 @@ VkDevice LogicalDevice::getDevice() const
 VkQueue LogicalDevice::getGraphicQueue() const
 {
     return this->g_graphicQueue;
+}
+VkQueue LogicalDevice::getComputeQueue() const
+{
+    return this->g_computeQueue;
+}
+VkQueue LogicalDevice::getTransferQueue() const
+{
+    return this->g_transferQueue;
 }
 VkQueue LogicalDevice::getPresentQueue() const
 {

--- a/sources/vulkan/C_logicalDevice.cpp
+++ b/sources/vulkan/C_logicalDevice.cpp
@@ -28,15 +28,21 @@ namespace fge::vulkan
 LogicalDevice::LogicalDevice() :
         g_device(VK_NULL_HANDLE),
         g_graphicQueue(VK_NULL_HANDLE),
+        g_computeQueue(VK_NULL_HANDLE),
+        g_transferQueue(VK_NULL_HANDLE),
         g_presentQueue(VK_NULL_HANDLE)
 {}
 LogicalDevice::LogicalDevice(LogicalDevice&& r) noexcept :
         g_device(r.g_device),
         g_graphicQueue(r.g_graphicQueue),
+        g_computeQueue(r.g_computeQueue),
+        g_transferQueue(r.g_transferQueue),
         g_presentQueue(r.g_presentQueue)
 {
     r.g_device = VK_NULL_HANDLE;
     r.g_graphicQueue = VK_NULL_HANDLE;
+    r.g_computeQueue = VK_NULL_HANDLE;
+    r.g_transferQueue = VK_NULL_HANDLE;
     r.g_presentQueue = VK_NULL_HANDLE;
 }
 LogicalDevice::~LogicalDevice()
@@ -85,12 +91,10 @@ void LogicalDevice::create(PhysicalDevice& physicalDevice, VkSurfaceKHR surface)
     createInfo.enabledExtensionCount = static_cast<uint32_t>(DeviceExtensions.size());
     createInfo.ppEnabledExtensionNames = DeviceExtensions.data();
 
-#ifdef NDEBUG
-    createInfo.enabledLayerCount = 0;
-#else
-    createInfo.enabledLayerCount = static_cast<uint32_t>(ValidationLayers.size());
-    createInfo.ppEnabledLayerNames = ValidationLayers.data();
-#endif
+    //https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation
+    //Device Layer Deprecation, but we still need this for compatibility
+    createInfo.enabledLayerCount = static_cast<uint32_t>(InstanceLayers.size());
+    createInfo.ppEnabledLayerNames = InstanceLayers.empty() ? nullptr : InstanceLayers.data();
 
     // Extended features goes here
 
@@ -137,6 +141,8 @@ void LogicalDevice::destroy()
         vkDestroyDevice(this->g_device, nullptr);
         this->g_device = VK_NULL_HANDLE;
         this->g_graphicQueue = VK_NULL_HANDLE;
+        this->g_computeQueue = VK_NULL_HANDLE;
+        this->g_transferQueue = VK_NULL_HANDLE;
         this->g_presentQueue = VK_NULL_HANDLE;
     }
 }

--- a/sources/vulkan/C_swapChain.cpp
+++ b/sources/vulkan/C_swapChain.cpp
@@ -104,11 +104,22 @@ void SwapChain::create(SDL_Window* window,
     createInfo.presentMode = this->g_presentMode;
     createInfo.clipped = VK_TRUE;
 
-    createInfo.oldSwapchain = VK_NULL_HANDLE;
+    auto oldSwapChain = this->g_swapChain;
+    createInfo.oldSwapchain = oldSwapChain;
 
     if (vkCreateSwapchainKHR(logicalDevice.getDevice(), &createInfo, nullptr, &this->g_swapChain) != VK_SUCCESS)
     {
         throw fge::Exception("failed to create swap chain!");
+    }
+
+    if (oldSwapChain != VK_NULL_HANDLE)
+    {
+        for (auto imageView: this->g_swapChainImageViews)
+        {
+            vkDestroyImageView(this->g_logicalDevice->getDevice(), imageView, nullptr);
+        }
+        vkDestroySwapchainKHR(logicalDevice.getDevice(), oldSwapChain, nullptr);
+        this->g_swapChainImageViews.clear();
     }
 
     vkGetSwapchainImagesKHR(logicalDevice.getDevice(), this->g_swapChain, &imageCount, nullptr);

--- a/sources/vulkan/C_vertexBuffer.cpp
+++ b/sources/vulkan/C_vertexBuffer.cpp
@@ -339,7 +339,14 @@ void VertexBuffer::mapBuffer() const
         memcpy(data, this->g_vertices.data(), size);
         vmaUnmapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation);
 
-        this->getContext().copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+        {
+            ///TODO: add submit type choice to the user
+            auto buffer = this->getContext().beginCommands(Context::SubmitTypes::DIRECT_WAIT_EXECUTION,
+                                                           CommandBuffer::RenderPassScopes::OUTSIDE,
+                                                           CommandBuffer::SUPPORTED_QUEUE_GRAPHICS);
+            buffer.copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+            this->getContext().submitCommands(std::move(buffer));
+        }
         break;
     default:
         return;
@@ -652,7 +659,14 @@ void IndexBuffer::mapBuffer() const
         memcpy(data, this->g_indices.data(), size);
         vmaUnmapMemory(this->getContext().getAllocator(), this->g_stagingBufferAllocation);
 
-        this->getContext().copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+        {
+            ///TODO: add submit type choice to the user
+            auto buffer = this->getContext().beginCommands(Context::SubmitTypes::DIRECT_WAIT_EXECUTION,
+                                                           CommandBuffer::RenderPassScopes::OUTSIDE,
+                                                           CommandBuffer::SUPPORTED_QUEUE_GRAPHICS);
+            buffer.copyBuffer(this->g_stagingBuffer, this->g_buffer, size);
+            this->getContext().submitCommands(std::move(buffer));
+        }
         break;
     default:
         return;

--- a/sources/vulkan/C_vertexBuffer.cpp
+++ b/sources/vulkan/C_vertexBuffer.cpp
@@ -207,14 +207,14 @@ void VertexBuffer::destroy()
     }
 }
 
-void VertexBuffer::bind(VkCommandBuffer commandBuffer) const
+void VertexBuffer::bind(CommandBuffer& commandBuffer) const
 {
     if (this->g_type != BufferTypes::UNINITIALIZED)
     {
         this->updateBuffer();
 
         VkDeviceSize const offsets[] = {0};
-        vkCmdBindVertexBuffers(commandBuffer, 0, 1, &this->g_buffer, offsets);
+        commandBuffer.bindVertexBuffers(0, 1, &this->g_buffer, offsets);
     }
 }
 
@@ -579,12 +579,12 @@ void IndexBuffer::destroy()
     }
 }
 
-void IndexBuffer::bind(VkCommandBuffer commandBuffer) const
+void IndexBuffer::bind(CommandBuffer& commandBuffer) const
 {
     if (this->g_type != BufferTypes::UNINITIALIZED)
     {
         this->updateBuffer();
-        vkCmdBindIndexBuffer(commandBuffer, this->g_buffer, 0, VK_INDEX_TYPE_UINT16);
+        commandBuffer.bindIndexBuffer(this->g_buffer, 0, VK_INDEX_TYPE_UINT16);
     }
 }
 

--- a/sources/vulkan/C_viewport.cpp
+++ b/sources/vulkan/C_viewport.cpp
@@ -65,9 +65,4 @@ VkViewport const& Viewport::getViewport() const
     return this->g_viewport;
 }
 
-void Viewport::cmdSetViewport(VkCommandBuffer commandBuffer) const
-{
-    vkCmdSetViewport(commandBuffer, 0, 1, &this->g_viewport);
-}
-
 } // namespace fge::vulkan

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -29,9 +29,9 @@ namespace fge::vulkan
 {
 
 #ifdef FGE_ENABLE_VALIDATION_LAYERS
-std::vector<char const*> ValidationLayers = {"VK_LAYER_KHRONOS_validation", "VK_LAYER_LUNARG_monitor"};
+std::vector<char const*> InstanceLayers = {"VK_LAYER_KHRONOS_validation", "VK_LAYER_LUNARG_monitor"};
 #else
-std::vector<char const*> ValidationLayers = {};
+std::vector<char const*> InstanceLayers = {};
 #endif
 
 std::vector<char const*> DeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
@@ -60,7 +60,7 @@ void SetActiveContext(Context& context)
     gActiveContext = &context;
 }
 
-bool CheckValidationLayerSupport(char const* layerName)
+bool CheckInstanceLayerSupport(char const* layerName)
 {
     static std::vector<VkLayerProperties> availableLayers;
 


### PR DESCRIPTION
- Add a CommandBuffer wrapper class
- Move out commands from classes to CommandBuffer
- Add "basic" support for transfer and compute queue
- SwapChain: add support for createInfo.oldSwapchain
- Rename ValidationLayers -> InstanceLayers, add the ability to set instance layers in release mode
