### PR TITLE
Object transfers and cleaning

### DIFF
--- a/examples/clientServerLifeSimulator_004/share/C_creature.cpp
+++ b/examples/clientServerLifeSimulator_004/share/C_creature.cpp
@@ -79,7 +79,7 @@ Creature::Creature(fge::Vector2f const& pos)
     this->setPosition(pos);
 }
 
-void Creature::first([[maybe_unused]] fge::Scene* scene)
+void Creature::first([[maybe_unused]] fge::Scene& scene)
 {
     this->g_animTexture.reset(new fge::texture::TextureData);
     this->g_animTexture->_valid = true;

--- a/examples/clientServerLifeSimulator_004/share/C_creature.cpp
+++ b/examples/clientServerLifeSimulator_004/share/C_creature.cpp
@@ -193,7 +193,7 @@ FGE_OBJ_UPDATE_BODY(Creature)
         if (this->_data._hunger >= 10)
         { //Finding food
             fge::ObjectContainer objects;
-            if (scene->getAllObj_ByClass("LS:OBJ:FOOD", objects) > 0)
+            if (scene.getAllObj_ByClass("LS:OBJ:FOOD", objects) > 0)
             {
                 for (auto& obj: objects)
                 {
@@ -210,7 +210,7 @@ FGE_OBJ_UPDATE_BODY(Creature)
         if (this->_data._thirst >= 10)
         { //Finding drink
             fge::ObjectContainer objects;
-            if (scene->getAllObj_ByClass("LS:OBJ:DRINK", objects) > 0)
+            if (scene.getAllObj_ByClass("LS:OBJ:DRINK", objects) > 0)
             {
                 for (auto& obj: objects)
                 {
@@ -227,7 +227,7 @@ FGE_OBJ_UPDATE_BODY(Creature)
         if (this->_data._libido >= 50)
         { //Finding partner
             fge::ObjectContainer objects;
-            if (scene->getAllObj_ByClass("LS:OBJ:CREATURE", objects) > 0)
+            if (scene.getAllObj_ByClass("LS:OBJ:CREATURE", objects) > 0)
             {
                 for (auto& obj: objects)
                 {
@@ -261,7 +261,7 @@ FGE_OBJ_UPDATE_BODY(Creature)
     }
     else
     { //Pending action
-        auto targetObject = scene->getObject(this->_actionQueue.front()._target);
+        auto targetObject = scene.getObject(this->_actionQueue.front()._target);
 
         if (targetObject)
         {
@@ -279,14 +279,14 @@ FGE_OBJ_UPDATE_BODY(Creature)
                 {
                     auto nutrition = targetObject->getObject<ls::Food>()->_nutrition;
                     this->_data._hunger = std::clamp(this->_data._hunger - nutrition, 0, 100);
-                    scene->delObject(targetObject->getSid());
+                    scene.delObject(targetObject->getSid());
                 }
                 break;
                 case Action::Types::ACTION_DRINK:
                 {
                     auto nutrition = targetObject->getObject<ls::Drink>()->_nutrition;
                     this->_data._thirst = std::clamp(this->_data._thirst - nutrition, 0, 100);
-                    scene->delObject(targetObject->getSid());
+                    scene.delObject(targetObject->getSid());
                 }
                 break;
                 case Action::Types::ACTION_MAKEBABY:

--- a/examples/clientServerLifeSimulator_004/share/C_drink.cpp
+++ b/examples/clientServerLifeSimulator_004/share/C_drink.cpp
@@ -26,7 +26,7 @@ Drink::Drink(fge::Vector2f const& pos)
     this->setPosition(pos);
 }
 
-void Drink::first([[maybe_unused]] fge::Scene* scene)
+void Drink::first([[maybe_unused]] fge::Scene& scene)
 {
     this->_nutrition = fge::_random.range(1, 20);
     this->setOrigin({24, 19});

--- a/examples/clientServerLifeSimulator_004/share/C_food.cpp
+++ b/examples/clientServerLifeSimulator_004/share/C_food.cpp
@@ -26,7 +26,7 @@ Food::Food(fge::Vector2f const& pos)
     this->setPosition(pos);
 }
 
-void Food::first([[maybe_unused]] fge::Scene* scene)
+void Food::first([[maybe_unused]] fge::Scene& scene)
 {
     this->_nutrition = fge::_random.range(1, 20);
     this->setOrigin({24, 19});

--- a/examples/clientServerLifeSimulator_004/share/includes/C_creature.hpp
+++ b/examples/clientServerLifeSimulator_004/share/includes/C_creature.hpp
@@ -92,7 +92,7 @@ public:
     explicit Creature(fge::Vector2f const& pos);
     ~Creature() override = default;
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     bool worldTick() override;
     FGE_OBJ_UPDATE_DECLARE
     FGE_OBJ_DRAW_DECLARE

--- a/examples/clientServerLifeSimulator_004/share/includes/C_drink.hpp
+++ b/examples/clientServerLifeSimulator_004/share/includes/C_drink.hpp
@@ -32,7 +32,7 @@ public:
 
     FGE_OBJ_DEFAULT_COPYMETHOD(Drink)
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     FGE_OBJ_DRAW_DECLARE
     void networkRegister() override;
 

--- a/examples/clientServerLifeSimulator_004/share/includes/C_food.hpp
+++ b/examples/clientServerLifeSimulator_004/share/includes/C_food.hpp
@@ -32,7 +32,7 @@ public:
 
     FGE_OBJ_DEFAULT_COPYMETHOD(Food)
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     FGE_OBJ_DRAW_DECLARE
     void networkRegister() override;
 

--- a/examples/lightAndObstacle_002/main.cpp
+++ b/examples/lightAndObstacle_002/main.cpp
@@ -88,9 +88,9 @@ public:
     void update([[maybe_unused]] fge::RenderWindow& screen,
                 [[maybe_unused]] fge::Event& event,
                 [[maybe_unused]] std::chrono::microseconds const& deltaTime,
-                [[maybe_unused]] fge::Scene* scene) override
+                [[maybe_unused]] fge::Scene& scene) override
     {
-        auto* follow = scene->_properties["follow"].getPtr<std::string>();
+        auto* follow = scene._properties["follow"].getPtr<std::string>();
         if (follow != nullptr && *follow == "obstacle" && !this->_tags.check("duplicate"))
         {
             this->setPosition(screen.mapFramebufferCoordsToViewSpace(event.getMousePixelPos()));

--- a/examples/lightAndObstacle_002/main.cpp
+++ b/examples/lightAndObstacle_002/main.cpp
@@ -75,7 +75,7 @@ public:
 
     FGE_OBJ_DEFAULT_COPYMETHOD(Obstacle)
 
-    void first([[maybe_unused]] fge::Scene* scene) override
+    void first([[maybe_unused]] fge::Scene& scene) override
     {
         if (!this->_g_lightSystemGate.isOpen())
         {

--- a/examples/tileMapAndPathFinding_001/main.cpp
+++ b/examples/tileMapAndPathFinding_001/main.cpp
@@ -34,7 +34,7 @@ public:
 
     FGE_OBJ_DEFAULT_COPYMETHOD(PathFinder)
 
-    void first([[maybe_unused]] fge::Scene* scene) override
+    void first([[maybe_unused]] fge::Scene& scene) override
     {
         this->_drawMode = fge::Object::DrawModes::DRAW_ALWAYS_DRAWN;
     }

--- a/includes/FastEngine/C_scene.hpp
+++ b/includes/FastEngine/C_scene.hpp
@@ -549,6 +549,15 @@ public:
      * The provided Scene must not have another Object with the same SID,
      * causing the method to failed and return an invalid shared pointer.
      *
+     * Events/methods are called in this order :
+     *    [Object destroyed from old Scene]
+     *    _onObjectRemoved called on old Scene
+     *    _onPlanUpdate called on old Scene
+     *    [Object is added in new Scene]
+     *    _onObjectAdded called on new Scene
+     *    _onPlanUpdate called on new Scene
+     *    Object::transfered() called
+     *
      * \warning This method is not meant to be used on the same Scene, however
      * it will work as expected.
      *

--- a/includes/FastEngine/C_scene.hpp
+++ b/includes/FastEngine/C_scene.hpp
@@ -1301,12 +1301,12 @@ public:
 
     // Event
     /// Event called when the Scene is about to be drawn
-    mutable fge::CallbackHandler<fge::Scene const*, fge::RenderTarget&> _onDraw;
+    mutable fge::CallbackHandler<fge::Scene const&, fge::RenderTarget&> _onDraw;
 
     /// Event called when a new Object has been added
-    mutable fge::CallbackHandler<fge::Scene*, fge::ObjectDataShared const&> _onObjectAdded;
+    mutable fge::CallbackHandler<fge::Scene&, fge::ObjectDataShared const&> _onObjectAdded;
     /// Event called when an Object has been removed
-    mutable fge::CallbackHandler<fge::Scene*, fge::ObjectDataShared const&> _onObjectRemoved;
+    mutable fge::CallbackHandler<fge::Scene&, fge::ObjectDataShared const&> _onObjectRemoved;
 
     /**
      * \brief Event called when a change in the plan is detected
@@ -1314,7 +1314,7 @@ public:
      * When an Object change his plan, is created, is deleted ... this event is called.
      * The ObjectPlan argument can be FGE_SCENE_BAD_PLAN, this mean that all plans have been impacted.
      */
-    mutable fge::CallbackHandler<fge::Scene*, fge::ObjectPlan> _onPlanUpdate;
+    mutable fge::CallbackHandler<fge::Scene&, fge::ObjectPlan> _onPlanUpdate;
 
     /**
      * \brief Event called only once after a Scene update
@@ -1322,7 +1322,7 @@ public:
      * You or an Object can register a one time callback that will be called after updating the Scene.
      * Once called, callbacks is cleared.
      */
-    mutable fge::CallbackHandler<fge::Scene*> _onDelayedUpdate;
+    mutable fge::CallbackHandler<fge::Scene&> _onDelayedUpdate;
 
 private:
     struct PerClientSync

--- a/includes/FastEngine/C_scene.hpp
+++ b/includes/FastEngine/C_scene.hpp
@@ -96,18 +96,19 @@ struct CallbackContext
  */
 struct SceneNetEvent
 {
-    enum Events : uint8_t
+    enum class Events : uint8_t
     {
-        SEVT_DELOBJECT = 0,
-        SEVT_NEWOBJECT,
+        OBJECT_DELETED = 0,
+        OBJECT_CREATED,
+        OBJECT_SIGNALED,
 
-        SEVT_UNKNOWN,
-
-        SEVT_MAX_
+        LAST_ENUM_
     };
+    using Events_t = std::underlying_type_t<Events>;
 
-    fge::SceneNetEvent::Events _event;
-    fge::ObjectSid _sid;
+    Events _event;
+    ObjectSid _sid;
+    int8_t _signal{0};
 };
 
 /**
@@ -929,6 +930,14 @@ public:
     virtual fge::ObjectSid generateSid(fge::ObjectSid wanted_sid = FGE_SCENE_BAD_SID) const;
 
     // Network
+    /**
+     * \brief Signal an Object over the network.
+     *
+     * \param sid The SID of the Object
+     * \param signal The signal to send
+     */
+    void signalObject(fge::ObjectSid sid, int8_t signal);
+
     /**
      * \brief Pack all the Scene data in a Packet.
      *

--- a/includes/FastEngine/object/C_childObjectsAccessor.hpp
+++ b/includes/FastEngine/object/C_childObjectsAccessor.hpp
@@ -60,12 +60,12 @@ public:
     void remove(std::size_t first, std::size_t last);
 
 #ifdef FGE_DEF_SERVER
-    void update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene* scene);
+    void update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene);
 #else
     void update(fge::RenderWindow& screen,
                 fge::Event& event,
                 std::chrono::microseconds const& deltaTime,
-                fge::Scene* scene) const;
+                fge::Scene& scene) const;
     void draw(fge::RenderTarget& target, fge::RenderStates const& states) const;
 #endif //FGE_DEF_SERVER
 

--- a/includes/FastEngine/object/C_lightSystem.hpp
+++ b/includes/FastEngine/object/C_lightSystem.hpp
@@ -42,13 +42,9 @@ using LightSystemGate = fge::TunnelGate<fge::LightComponent>;
  * \param scene The scene to get the light system from
  * \return The default light system
  */
-inline fge::LightSystem* GetDefaultLightSystem(fge::Scene* scene)
+inline fge::LightSystem* GetDefaultLightSystem(fge::Scene& scene)
 {
-    if (scene != nullptr)
-    {
-        return scene->_properties.getProperty(FGE_LIGHT_PROPERTY_DEFAULT_LS).get<fge::LightSystem*>().value_or(nullptr);
-    }
-    return nullptr;
+    return scene._properties.getProperty(FGE_LIGHT_PROPERTY_DEFAULT_LS).get<fge::LightSystem*>().value_or(nullptr);
 }
 
 /**
@@ -105,7 +101,7 @@ public:
      *
      * \param scene The scene to get the light system from
      */
-    inline void setDefaultLightSystem(fge::Scene* scene)
+    inline void setDefaultLightSystem(fge::Scene& scene)
     {
         auto* ls = fge::GetDefaultLightSystem(scene);
         if (ls != nullptr)

--- a/includes/FastEngine/object/C_objLight.hpp
+++ b/includes/FastEngine/object/C_objLight.hpp
@@ -56,7 +56,7 @@ public:
 
     fge::Color getColor() const;
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     FGE_OBJ_UPDATE_DECLARE
     FGE_OBJ_DRAW_DECLARE
 

--- a/includes/FastEngine/object/C_objRenderMap.hpp
+++ b/includes/FastEngine/object/C_objRenderMap.hpp
@@ -44,7 +44,7 @@ public:
     void first(fge::Scene& scene) override;
     FGE_OBJ_UPDATE_DECLARE
     FGE_OBJ_DRAW_DECLARE
-    void removed(fge::Scene* scene) override;
+    void removed(fge::Scene& scene) override;
 
     void save(nlohmann::json& jsonObject, fge::Scene* scene) override;
     void load(nlohmann::json& jsonObject, fge::Scene* scene) override;

--- a/includes/FastEngine/object/C_objRenderMap.hpp
+++ b/includes/FastEngine/object/C_objRenderMap.hpp
@@ -41,7 +41,7 @@ public:
     void setClearColor(fge::Color const& color);
     fge::Color const& getClearColor() const;
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     FGE_OBJ_UPDATE_DECLARE
     FGE_OBJ_DRAW_DECLARE
     void removed(fge::Scene* scene) override;

--- a/includes/FastEngine/object/C_objRenderMap.hpp
+++ b/includes/FastEngine/object/C_objRenderMap.hpp
@@ -36,7 +36,7 @@ public:
 
     fge::Object* copy() override { return new fge::ObjRenderMap(); }
 
-    void onDraw(fge::Scene const* scene, fge::RenderTarget& target);
+    void onDraw(fge::Scene const& scene, fge::RenderTarget& target);
 
     void setClearColor(fge::Color const& color);
     fge::Color const& getClearColor() const;

--- a/includes/FastEngine/object/C_objShape.hpp
+++ b/includes/FastEngine/object/C_objShape.hpp
@@ -79,7 +79,7 @@ public:
     [[nodiscard]] virtual std::size_t getPointCount() const = 0;
     [[nodiscard]] virtual Vector2f getPoint(std::size_t index) const = 0;
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
 
     FGE_OBJ_DRAW_DECLARE
 

--- a/includes/FastEngine/object/C_objSlider.hpp
+++ b/includes/FastEngine/object/C_objSlider.hpp
@@ -37,7 +37,7 @@ public:
 
     fge::GuiElement* getGuiElement() override { return this; }
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     void callbackRegister(fge::Event& event, fge::GuiElementHandler* guiElementHandlerPtr) override;
     FGE_OBJ_DRAW_DECLARE
 

--- a/includes/FastEngine/object/C_objTextList.hpp
+++ b/includes/FastEngine/object/C_objTextList.hpp
@@ -38,7 +38,7 @@ public:
 
     FGE_OBJ_DEFAULT_COPYMETHOD(fge::ObjTextList)
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     void callbackRegister(fge::Event& event, fge::GuiElementHandler* guiElementHandlerPtr) override;
     FGE_OBJ_DRAW_DECLARE
 

--- a/includes/FastEngine/object/C_objWindow.hpp
+++ b/includes/FastEngine/object/C_objWindow.hpp
@@ -57,7 +57,7 @@ public:
 
     fge::GuiElement* getGuiElement() override { return this; }
 
-    void first(fge::Scene* scene) override;
+    void first(fge::Scene& scene) override;
     void callbackRegister(fge::Event& event, fge::GuiElementHandler* guiElementHandlerPtr) override;
     void removed(fge::Scene* scene) override;
 

--- a/includes/FastEngine/object/C_objWindow.hpp
+++ b/includes/FastEngine/object/C_objWindow.hpp
@@ -59,7 +59,7 @@ public:
 
     void first(fge::Scene& scene) override;
     void callbackRegister(fge::Event& event, fge::GuiElementHandler* guiElementHandlerPtr) override;
-    void removed(fge::Scene* scene) override;
+    void removed(fge::Scene& scene) override;
 
     FGE_OBJ_UPDATE_DECLARE
     FGE_OBJ_DRAW_DECLARE

--- a/includes/FastEngine/object/C_objWindow.hpp
+++ b/includes/FastEngine/object/C_objWindow.hpp
@@ -116,8 +116,8 @@ private:
     void onMouseButtonReleased(fge::Event const& evt, SDL_MouseButtonEvent const& arg);
     void onMouseMoved(fge::Event const& evt, SDL_MouseMotionEvent const& arg);
 
-    void onPlanUpdate(fge::Scene* scene, fge::ObjectPlan plan);
-    void onObjectAdded(fge::Scene* scene, fge::ObjectDataShared const& object);
+    void onPlanUpdate(fge::Scene& scene, fge::ObjectPlan plan);
+    void onObjectAdded(fge::Scene& scene, fge::ObjectDataShared const& object);
 
     void onRefreshGlobalScale(fge::Vector2f const& scale);
 

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -118,9 +118,9 @@ public:
     /**
      * \brief Method called when the object is added to a scene for initialization purposes.
      *
-     * \param scene The scene where the object is added (can be nullptr)
+     * \param scene The scene where the object is added
      */
-    virtual void first(fge::Scene* scene);
+    virtual void first(fge::Scene& scene);
     /**
      * \brief Ask the object to register all callbacks it needs to receive events.
      *

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -43,18 +43,18 @@
 
 #ifdef FGE_DEF_SERVER
     #define FGE_OBJ_UPDATE_DECLARE                                                                                     \
-        void update(fge::Event& event, const std::chrono::microseconds& deltaTime, fge::Scene* scene) override;
+        void update(fge::Event& event, const std::chrono::microseconds& deltaTime, fge::Scene& scene) override;
 #else
     #define FGE_OBJ_UPDATE_DECLARE                                                                                     \
         void update(fge::RenderWindow& screen, fge::Event& event, const std::chrono::microseconds& deltaTime,          \
-                    fge::Scene* scene) override;
+                    fge::Scene& scene) override;
 #endif //FGE_DEF_SERVER
 
 #ifdef FGE_DEF_SERVER
     #define FGE_OBJ_UPDATE_BODY(class_)                                                                                \
         void class_::update([[maybe_unused]] fge::Event& event,                                                        \
                             [[maybe_unused]] const std::chrono::microseconds& deltaTime,                               \
-                            [[maybe_unused]] fge::Scene* scene)
+                            [[maybe_unused]] fge::Scene& scene)
 
     #define FGE_OBJ_UPDATE_CALL(object_) object_.update(event, deltaTime, scene)
     #define FGE_OBJ_UPDATE_PTRCALL(object_) object_->update(event, deltaTime, scene)
@@ -62,7 +62,7 @@
     #define FGE_OBJ_UPDATE_BODY(class_)                                                                                \
         void class_::update([[maybe_unused]] fge::RenderWindow& screen, [[maybe_unused]] fge::Event& event,            \
                             [[maybe_unused]] const std::chrono::microseconds& deltaTime,                               \
-                            [[maybe_unused]] fge::Scene* scene)
+                            [[maybe_unused]] fge::Scene& scene)
 
     #define FGE_OBJ_UPDATE_CALL(object_) object_.update(screen, event, deltaTime, scene)
     #define FGE_OBJ_UPDATE_PTRCALL(object_) object_->update(screen, event, deltaTime, scene)
@@ -144,13 +144,13 @@ public:
      * \param screen The screen where the object is drawn
      * \param event The event system
      * \param deltaTime The time since the last frame
-     * \param scene The scene where the object is updated (can be nullptr)
+     * \param scene The scene where the object is updated
      */
 #ifdef FGE_DEF_SERVER
-    virtual void update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene* scene);
+    virtual void update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene);
 #else
     virtual void
-    update(fge::RenderWindow& screen, fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene* scene);
+    update(fge::RenderWindow& screen, fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene);
 #endif //FGE_DEF_SERVER
     /**
      * \brief Method called every frame to draw the object

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -122,6 +122,16 @@ public:
      */
     virtual void first(fge::Scene& scene);
     /**
+     * \brief Method called when the object is transferred from a scene to another.
+     *
+     * This method is called after the object is removed from the old scene and added to the new scene.
+     * The _myObjectData is updated to the new scene when this method is called.
+     *
+     * \param oldScene The old scene where the object was
+     * \param newScene The new scene where the object is
+     */
+    virtual void transfered(fge::Scene& oldScene, fge::Scene& newScene);
+    /**
      * \brief Ask the object to register all callbacks it needs to receive events.
      *
      * \param event The event system

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -148,9 +148,11 @@ public:
      */
 #ifdef FGE_DEF_SERVER
     virtual void update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene);
+    void update(fge::Event& event, std::chrono::microseconds const& deltaTime);
 #else
     virtual void
     update(fge::RenderWindow& screen, fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene);
+    void update(fge::RenderWindow& screen, fge::Event& event, std::chrono::microseconds const& deltaTime);
 #endif //FGE_DEF_SERVER
     /**
      * \brief Method called every frame to draw the object

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -158,9 +158,9 @@ public:
     /**
      * \brief Method called when the object is removed from a scene
      *
-     * \param scene The scene where the object is removed (can be nullptr)
+     * \param scene The scene where the object is removed
      */
-    virtual void removed(fge::Scene* scene);
+    virtual void removed(fge::Scene& scene);
 
     /**
      * \brief Save the object to a json object

--- a/includes/FastEngine/object/C_object.hpp
+++ b/includes/FastEngine/object/C_object.hpp
@@ -168,6 +168,12 @@ public:
      */
     virtual void networkRegister();
     /**
+     * \brief Method called when the object is signaled by the network
+     *
+     * \param signal The signal received
+     */
+    virtual void netSignaled(int8_t signal);
+    /**
      * \brief Method called when the object is removed from a scene
      *
      * \param scene The scene where the object is removed

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -155,16 +155,16 @@ void Scene::update(fge::RenderWindow& screen,
         }
 
 #ifdef FGE_DEF_SERVER
-        updatedObject->g_object->update(event, deltaTime, this);
+        updatedObject->g_object->update(event, deltaTime, *this);
         if ((updatedObject->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_UPDATE) > 0)
         {
-            updatedObject->g_object->_children.update(event, deltaTime, this);
+            updatedObject->g_object->_children.update(event, deltaTime, *this);
         }
 #else
-        updatedObject->g_object->update(screen, event, deltaTime, this);
+        updatedObject->g_object->update(screen, event, deltaTime, *this);
         if ((updatedObject->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_UPDATE) > 0)
         {
-            updatedObject->g_object->_children.update(screen, event, deltaTime, this);
+            updatedObject->g_object->_children.update(screen, event, deltaTime, *this);
         }
 #endif //FGE_DEF_SERVER
 

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -475,6 +475,7 @@ fge::ObjectDataShared Scene::transferObject(fge::ObjectSid sid, fge::Scene& newS
             buff = newScene.newObject(buff, true);
 
             buff->g_object->transfered(*this, newScene);
+            return buff;
         }
     }
     return nullptr;

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -459,12 +459,7 @@ fge::ObjectDataShared Scene::transferObject(fge::ObjectSid sid, fge::Scene& newS
         if (!newScene.isValid(sid))
         {
             fge::ObjectDataShared buff = *it->second;
-            buff->g_object->removed(*this);
-            if ((buff->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) >
-                0)
-            {
-                buff->g_object->_children.clear();
-            }
+
             this->hash_updatePlanDataMap(buff->g_plan, it->second, true);
             this->g_data.erase(it->second);
             this->g_dataMap.erase(it);
@@ -477,7 +472,9 @@ fge::ObjectDataShared Scene::transferObject(fge::ObjectSid sid, fge::Scene& newS
                 this->pushEvent({fge::SceneNetEvent::SEVT_DELOBJECT, sid});
             }
 
-            return newScene.newObject(buff);
+            buff = newScene.newObject(buff, true);
+
+            buff->g_object->transfered(*this, newScene);
         }
     }
     return nullptr;

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -176,7 +176,7 @@ void Scene::update(fge::RenderWindow& screen,
                 this->pushEvent({fge::SceneNetEvent::SEVT_DELOBJECT, updatedObject->g_sid});
             }
 
-            updatedObject->g_object->removed(this);
+            updatedObject->g_object->removed(*this);
             if ((updatedObject->g_object->_childrenControlFlags &
                  Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) > 0)
             {
@@ -459,7 +459,7 @@ fge::ObjectDataShared Scene::transferObject(fge::ObjectSid sid, fge::Scene& newS
         if (!newScene.isValid(sid))
         {
             fge::ObjectDataShared buff = *it->second;
-            buff->g_object->removed(this);
+            buff->g_object->removed(*this);
             if ((buff->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) >
                 0)
             {
@@ -500,7 +500,7 @@ bool Scene::delObject(fge::ObjectSid sid)
 
         auto buff = *it->second;
 
-        buff->g_object->removed(this);
+        buff->g_object->removed(*this);
         if ((buff->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) > 0)
         {
             buff->g_object->_children.clear();
@@ -542,7 +542,7 @@ std::size_t Scene::delAllObject(bool ignoreGuiObject)
             }
         }
 
-        buff->g_object->removed(this);
+        buff->g_object->removed(*this);
         if ((buff->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) > 0)
         {
             buff->g_object->_children.clear();
@@ -612,7 +612,7 @@ bool Scene::setObject(fge::ObjectSid sid, fge::ObjectPtr&& newObject)
 
         auto buff = *it->second;
 
-        buff->g_object->removed(this);
+        buff->g_object->removed(*this);
         if ((buff->g_object->_childrenControlFlags & Object::ChildrenControlFlags::CHILDREN_AUTO_CLEAR_ON_REMOVE) > 0)
         {
             buff->g_object->_children.clear();

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -189,8 +189,8 @@ void Scene::update(fge::RenderWindow& screen,
             this->hash_updatePlanDataMap(objectPlan, this->g_updatedObjectIterator, true);
             this->g_updatedObjectIterator = --this->g_data.erase(this->g_updatedObjectIterator);
 
-            this->_onObjectRemoved.call(this, updatedObject);
-            this->_onPlanUpdate.call(this, objectPlan);
+            this->_onObjectRemoved.call(*this, updatedObject);
+            this->_onPlanUpdate.call(*this, objectPlan);
         }
     }
 
@@ -199,7 +199,7 @@ void Scene::update(fge::RenderWindow& screen,
         ++this->g_updateCount;
     }
 
-    this->_onDelayedUpdate.call(this);
+    this->_onDelayedUpdate.call(*this);
     this->_onDelayedUpdate.clear();
 }
 uint16_t Scene::getUpdateCount() const
@@ -210,7 +210,7 @@ uint16_t Scene::getUpdateCount() const
 #ifndef FGE_DEF_SERVER
 void Scene::draw(fge::RenderTarget& target, fge::RenderStates const& states) const
 {
-    this->_onDraw.call(this, target);
+    this->_onDraw.call(*this, target);
 
     fge::RectFloat const screenBounds = fge::GetScreenRect(target);
 
@@ -285,7 +285,7 @@ fge::ObjectPlanDepth Scene::updatePlanDepth(fge::ObjectSid sid)
         fge::ObjectPlanDepth const planDepth = std::distance(firstPlanObjectIt, it->second);
         it->second->get()->g_planDepth = planDepth;
 
-        this->_onPlanUpdate.call(this, plan);
+        this->_onPlanUpdate.call(*this, plan);
         return planDepth;
     }
     return FGE_SCENE_BAD_PLANDEPTH;
@@ -307,7 +307,7 @@ void Scene::updateAllPlanDepth(fge::ObjectPlan plan)
             (*objectIt)->g_planDepth = depthCount++;
         }
 
-        this->_onPlanUpdate.call(this, plan);
+        this->_onPlanUpdate.call(*this, plan);
     }
 }
 void Scene::updateAllPlanDepth()
@@ -330,7 +330,7 @@ void Scene::updateAllPlanDepth()
         (*objectIt)->g_planDepth = depthCount++;
     }
 
-    this->_onPlanUpdate.call(this, FGE_SCENE_BAD_PLAN);
+    this->_onPlanUpdate.call(*this, FGE_SCENE_BAD_PLAN);
 }
 
 void Scene::clear()
@@ -383,8 +383,8 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectPtr&& newObject,
         (*it)->g_object->callbackRegister(*this->g_callbackContext._event, this->g_callbackContext._guiElementHandler);
     }
 
-    this->_onObjectAdded.call(this, *it);
-    this->_onPlanUpdate.call(this, plan);
+    this->_onObjectAdded.call(*this, *it);
+    this->_onPlanUpdate.call(*this, plan);
 
     return *it;
 }
@@ -425,8 +425,8 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectDataShared const& objectData, 
                                                this->g_callbackContext._guiElementHandler);
     }
 
-    this->_onObjectAdded.call(this, objectData);
-    this->_onPlanUpdate.call(this, objectData->g_plan);
+    this->_onObjectAdded.call(*this, objectData);
+    this->_onPlanUpdate.call(*this, objectData->g_plan);
 
     return objectData;
 }
@@ -464,8 +464,8 @@ fge::ObjectDataShared Scene::transferObject(fge::ObjectSid sid, fge::Scene& newS
             this->g_data.erase(it->second);
             this->g_dataMap.erase(it);
 
-            this->_onObjectRemoved.call(this, buff);
-            this->_onPlanUpdate.call(this, buff->g_plan);
+            this->_onObjectRemoved.call(*this, buff);
+            this->_onPlanUpdate.call(*this, buff->g_plan);
 
             if (this->g_enableNetworkEventsFlag)
             {
@@ -511,8 +511,8 @@ bool Scene::delObject(fge::ObjectSid sid)
         this->g_data.erase(it->second);
         this->g_dataMap.erase(it);
 
-        this->_onObjectRemoved.call(this, buff);
-        this->_onPlanUpdate.call(this, objectPlan);
+        this->_onObjectRemoved.call(*this, buff);
+        this->_onPlanUpdate.call(*this, objectPlan);
 
         return true;
     }
@@ -552,10 +552,10 @@ std::size_t Scene::delAllObject(bool ignoreGuiObject)
         this->g_dataMap.erase(buff->g_sid);
         it = --this->g_data.erase(it);
 
-        this->_onObjectRemoved.call(this, buff);
+        this->_onObjectRemoved.call(*this, buff);
     }
 
-    this->_onPlanUpdate.call(this, FGE_SCENE_BAD_PLAN);
+    this->_onPlanUpdate.call(*this, FGE_SCENE_BAD_PLAN);
     return buffSize;
 }
 
@@ -650,9 +650,9 @@ bool Scene::setObjectPlan(fge::ObjectSid sid, fge::ObjectPlan newPlan)
 
         if (oldPlan != newPlan)
         {
-            this->_onPlanUpdate.call(this, oldPlan);
+            this->_onPlanUpdate.call(*this, oldPlan);
         }
-        this->_onPlanUpdate.call(this, newPlan);
+        this->_onPlanUpdate.call(*this, newPlan);
         return true;
     }
     return false;
@@ -673,7 +673,7 @@ bool Scene::setObjectPlanTop(fge::ObjectSid sid)
         this->g_data.splice(newPosIt->second, this->g_data, it->second);
         this->hash_updatePlanDataMap((*it->second)->g_plan, it->second, false);
 
-        this->_onPlanUpdate.call(this, (*it->second)->g_plan);
+        this->_onPlanUpdate.call(*this, (*it->second)->g_plan);
         return true;
     }
     return false;
@@ -713,7 +713,7 @@ bool Scene::setObjectPlanBot(fge::ObjectSid sid)
             }
         }
 
-        this->_onPlanUpdate.call(this, plan);
+        this->_onPlanUpdate.call(*this, plan);
 
         return true;
     }

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -374,7 +374,7 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectPtr&& newObject,
     }
     if (!silent)
     {
-        (*it)->g_object->first(this);
+        (*it)->g_object->first(*this);
     }
 
     if ((*it)->g_object->_callbackContextMode == fge::Object::CallbackContextModes::CONTEXT_AUTO &&
@@ -415,7 +415,7 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectDataShared const& objectData, 
     }
     if (!silent)
     {
-        objectData->g_object->first(this);
+        objectData->g_object->first(*this);
     }
 
     if (objectData->g_object->_callbackContextMode == fge::Object::CallbackContextModes::CONTEXT_AUTO &&
@@ -622,7 +622,7 @@ bool Scene::setObject(fge::ObjectSid sid, fge::ObjectPtr&& newObject)
 
         buff = std::make_shared<fge::ObjectData>(this, std::move(newObject), buff->g_sid, buff->g_plan, buff->g_type);
         buff->g_object->_myObjectData = *it->second;
-        buff->g_object->first(this);
+        buff->g_object->first(*this);
 
         if (buff->g_object->_callbackContextMode == fge::Object::CallbackContextModes::CONTEXT_AUTO &&
             this->g_callbackContext._event != nullptr)

--- a/sources/object/C_childObjectsAccessor.cpp
+++ b/sources/object/C_childObjectsAccessor.cpp
@@ -126,7 +126,7 @@ void ChildObjectsAccessor::remove(std::size_t first, std::size_t last)
 }
 
 #ifdef FGE_DEF_SERVER
-void ChildObjectsAccessor::update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene* scene)
+void ChildObjectsAccessor::update(fge::Event& event, std::chrono::microseconds const& deltaTime, fge::Scene& scene)
 {
     for (this->g_actualIteratedIndex = 0; this->g_actualIteratedIndex < this->g_data.size();
          ++this->g_actualIteratedIndex)
@@ -138,7 +138,7 @@ void ChildObjectsAccessor::update(fge::Event& event, std::chrono::microseconds c
 void ChildObjectsAccessor::update(fge::RenderWindow& screen,
                                   fge::Event& event,
                                   std::chrono::microseconds const& deltaTime,
-                                  fge::Scene* scene) const
+                                  fge::Scene& scene) const
 {
     for (this->g_actualIteratedIndex = 0; this->g_actualIteratedIndex < this->g_data.size();
          ++this->g_actualIteratedIndex)

--- a/sources/object/C_objLight.cpp
+++ b/sources/object/C_objLight.cpp
@@ -109,11 +109,11 @@ fge::Color ObjLight::getColor() const
     return fge::Color(this->g_vertexBuffer.getVertices()[0]._color);
 }
 
-void ObjLight::first(fge::Scene* scene)
+void ObjLight::first(fge::Scene& scene)
 {
-    if (scene != nullptr && !this->g_renderObject)
+    if (!this->g_renderObject)
     {
-        this->g_renderObject = scene->getFirstObj_ByClass(FGE_OBJRENDERMAP_CLASSNAME);
+        this->g_renderObject = scene.getFirstObj_ByClass(FGE_OBJRENDERMAP_CLASSNAME);
     }
     if (!this->_g_lightSystemGate.isOpen())
     {

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -46,7 +46,7 @@ ObjRenderMap::ObjRenderMap(fge::ObjRenderMap& r) :
     this->g_vertexBuffer.create(4, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 }
 
-void ObjRenderMap::onDraw([[maybe_unused]] fge::Scene const* scene, [[maybe_unused]] fge::RenderTarget& target)
+void ObjRenderMap::onDraw([[maybe_unused]] fge::Scene const& scene, [[maybe_unused]] fge::RenderTarget& target)
 {
     this->_renderTexture.setClearColor(this->g_colorClear);
     this->_renderTexture.beginRenderPass(this->_renderTexture.prepareNextFrame(nullptr));

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -61,12 +61,9 @@ fge::Color const& ObjRenderMap::getClearColor() const
     return this->g_colorClear;
 }
 
-void ObjRenderMap::first(fge::Scene* scene)
+void ObjRenderMap::first(fge::Scene& scene)
 {
-    if (scene != nullptr)
-    {
-        scene->_onDraw.addObjectFunctor(&fge::ObjRenderMap::onDraw, this, this);
-    }
+    scene._onDraw.addObjectFunctor(&fge::ObjRenderMap::onDraw, this, this);
 }
 
 #ifdef FGE_DEF_SERVER

--- a/sources/object/C_objRenderMap.cpp
+++ b/sources/object/C_objRenderMap.cpp
@@ -105,7 +105,7 @@ FGE_OBJ_DRAW_BODY(ObjRenderMap)
 }
 #endif
 
-void ObjRenderMap::removed([[maybe_unused]] fge::Scene* scene)
+void ObjRenderMap::removed([[maybe_unused]] fge::Scene& scene)
 {
     this->detachAll();
 }

--- a/sources/object/C_objShape.cpp
+++ b/sources/object/C_objShape.cpp
@@ -219,7 +219,7 @@ void ObjShape::updateShape()
     this->updateOutline();
 }
 
-void ObjShape::first([[maybe_unused]] fge::Scene* scene)
+void ObjShape::first([[maybe_unused]] fge::Scene& scene)
 {
     this->updateShape();
 }

--- a/sources/object/C_objSlider.cpp
+++ b/sources/object/C_objSlider.cpp
@@ -21,7 +21,7 @@
 namespace fge
 {
 
-void ObjSlider::first([[maybe_unused]] fge::Scene* scene)
+void ObjSlider::first([[maybe_unused]] fge::Scene& scene)
 {
     this->_drawMode = fge::Object::DrawModes::DRAW_ALWAYS_DRAWN;
 

--- a/sources/object/C_objTextList.cpp
+++ b/sources/object/C_objTextList.cpp
@@ -51,7 +51,7 @@ ObjTextList::ObjTextList(ObjTextList const& r) :
     }*/
 }
 
-void ObjTextList::first([[maybe_unused]] fge::Scene* scene)
+void ObjTextList::first([[maybe_unused]] fge::Scene& scene)
 {
     this->_drawMode = fge::Object::DrawModes::DRAW_ALWAYS_DRAWN;
 }

--- a/sources/object/C_objWindow.cpp
+++ b/sources/object/C_objWindow.cpp
@@ -451,7 +451,7 @@ void ObjWindow::onMouseMoved([[maybe_unused]] fge::Event const& evt, SDL_MouseMo
     }
 }
 
-void ObjWindow::onPlanUpdate([[maybe_unused]] fge::Scene* scene, fge::ObjectPlan plan)
+void ObjWindow::onPlanUpdate([[maybe_unused]] fge::Scene& scene, fge::ObjectPlan plan)
 {
     auto myObjectData = this->_myObjectData.lock();
     if (myObjectData->getPlan() == plan)
@@ -463,7 +463,7 @@ void ObjWindow::onPlanUpdate([[maybe_unused]] fge::Scene* scene, fge::ObjectPlan
         this->setPriority(myObjectData->getPlan() + myObjectData->getPlanDepth());
     }
 }
-void ObjWindow::onObjectAdded([[maybe_unused]] fge::Scene* scene, fge::ObjectDataShared const& object)
+void ObjWindow::onObjectAdded([[maybe_unused]] fge::Scene& scene, fge::ObjectDataShared const& object)
 {
     object->setParent(this->_myObjectData.lock());
 }

--- a/sources/object/C_objWindow.cpp
+++ b/sources/object/C_objWindow.cpp
@@ -116,7 +116,7 @@ ObjWindow::ObjWindow(ObjWindow const& r) :
     this->g_spriteBatches.setTexture(this->g_tileSetWindow.getTexture());
 }
 
-void ObjWindow::first(fge::Scene* scene)
+void ObjWindow::first(fge::Scene& scene)
 {
     this->_drawMode = fge::Object::DrawModes::DRAW_ALWAYS_DRAWN;
 
@@ -125,7 +125,7 @@ void ObjWindow::first(fge::Scene* scene)
     this->setScale(fge::GuiElement::getGlobalGuiScale());
 
     this->_windowScene._properties.setProperty(FGE_OBJWINDOW_SCENE_PARENT_PROPERTY, this);
-    this->_windowScene.setLinkedRenderTarget(scene->getLinkedRenderTarget());
+    this->_windowScene.setLinkedRenderTarget(scene.getLinkedRenderTarget());
     this->_windowView.reset(new fge::View{});
     this->_windowScene.setCustomView(this->_windowView);
 

--- a/sources/object/C_objWindow.cpp
+++ b/sources/object/C_objWindow.cpp
@@ -173,7 +173,7 @@ void ObjWindow::callbackRegister(fge::Event& event, fge::GuiElementHandler* guiE
         objectData->getObject()->needAnchorUpdate(false);
     }
 }
-void ObjWindow::removed([[maybe_unused]] fge::Scene* scene)
+void ObjWindow::removed([[maybe_unused]] fge::Scene& scene)
 {
     this->detachAll();
 }

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -49,12 +49,12 @@ void Object::callbackRegister([[maybe_unused]] fge::Event& event,
 #ifdef FGE_DEF_SERVER
 void Object::update([[maybe_unused]] fge::Event& event,
                     [[maybe_unused]] std::chrono::microseconds const& deltaTime,
-                    [[maybe_unused]] fge::Scene* scene)
+                    [[maybe_unused]] fge::Scene& scene)
 #else
 void Object::update([[maybe_unused]] fge::RenderWindow& screen,
                     [[maybe_unused]] fge::Event& event,
                     [[maybe_unused]] std::chrono::microseconds const& deltaTime,
-                    [[maybe_unused]] fge::Scene* scene)
+                    [[maybe_unused]] fge::Scene& scene)
 #endif //FGE_DEF_SERVER
 {}
 

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -41,7 +41,7 @@ Object::Object(Object&& r) noexcept :
         _children(this)
 {}
 
-void Object::first([[maybe_unused]] fge::Scene* scene) {}
+void Object::first([[maybe_unused]] fge::Scene& scene) {}
 void Object::callbackRegister([[maybe_unused]] fge::Event& event,
                               [[maybe_unused]] fge::GuiElementHandler* guiElementHandlerPtr)
 {}

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -42,6 +42,7 @@ Object::Object(Object&& r) noexcept :
 {}
 
 void Object::first([[maybe_unused]] fge::Scene& scene) {}
+void Object::transfered([[maybe_unused]] fge::Scene& oldScene, [[maybe_unused]] fge::Scene& newScene) {}
 void Object::callbackRegister([[maybe_unused]] fge::Event& event,
                               [[maybe_unused]] fge::GuiElementHandler* guiElementHandlerPtr)
 {}

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -61,7 +61,7 @@ void Object::update([[maybe_unused]] fge::RenderWindow& screen,
 void Object::draw([[maybe_unused]] fge::RenderTarget& target, [[maybe_unused]] fge::RenderStates const& states) const {}
 #endif //FGE_DEF_SERVER
 void Object::networkRegister() {}
-void Object::removed([[maybe_unused]] fge::Scene* scene) {}
+void Object::removed([[maybe_unused]] fge::Scene& scene) {}
 
 fge::Object* Object::copy()
 {

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -77,6 +77,7 @@ void Object::update(fge::RenderWindow& screen, fge::Event& event, std::chrono::m
 void Object::draw([[maybe_unused]] fge::RenderTarget& target, [[maybe_unused]] fge::RenderStates const& states) const {}
 #endif //FGE_DEF_SERVER
 void Object::networkRegister() {}
+void Object::netSignaled([[maybe_unused]] int8_t signal) {}
 void Object::removed([[maybe_unused]] fge::Scene& scene) {}
 
 fge::Object* Object::copy()

--- a/sources/object/C_object.cpp
+++ b/sources/object/C_object.cpp
@@ -50,13 +50,28 @@ void Object::callbackRegister([[maybe_unused]] fge::Event& event,
 void Object::update([[maybe_unused]] fge::Event& event,
                     [[maybe_unused]] std::chrono::microseconds const& deltaTime,
                     [[maybe_unused]] fge::Scene& scene)
+{}
+void Object::update(fge::Event& event, std::chrono::microseconds const& deltaTime)
+{
+    if (auto myObject = this->_myObjectData.lock())
+    {
+        this->update(event, deltaTime, *myObject->getLinkedScene());
+    }
+}
 #else
 void Object::update([[maybe_unused]] fge::RenderWindow& screen,
                     [[maybe_unused]] fge::Event& event,
                     [[maybe_unused]] std::chrono::microseconds const& deltaTime,
                     [[maybe_unused]] fge::Scene& scene)
-#endif //FGE_DEF_SERVER
 {}
+void Object::update(fge::RenderWindow& screen, fge::Event& event, std::chrono::microseconds const& deltaTime)
+{
+    if (auto myObject = this->_myObjectData.lock())
+    {
+        this->update(screen, event, deltaTime, *myObject->getLinkedScene());
+    }
+}
+#endif //FGE_DEF_SERVER
 
 #ifndef FGE_DEF_SERVER
 void Object::draw([[maybe_unused]] fge::RenderTarget& target, [[maybe_unused]] fge::RenderStates const& states) const {}


### PR DESCRIPTION
Changes Overview:

Object Class:
- Modified first() and removed() methods to take a reference to a Scene instead of a pointer, ensuring the Scene cannot be null.
- Introduced a new virtual method transfered().
- Updated update() method to use a reference instead of a pointer.
- Added helper update() methods that do not require a Scene parameter, utilizing _myObjectData.
- Added a virtual method netSignaled() for network signaling.

Scene Class:
- Modified transferObject() to utilize Object::transfered().
- Fixed transferObject() to return the object pointer correctly.
- Replaced pointers with references for callback methods.
- Added OBJECT_SIGNALED network event and signalObject() method.
- Cleaned up SceneNetEvent.

These changes improve the robustness and readability of the Object and Scene classes by removing null pointer possibilities and streamlining event handling.
