### PR TITLE
Better memory allocation

### DIFF
--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -340,12 +340,18 @@ public:
      */
     [[nodiscard]] VmaAllocator getAllocator() const;
 
-    [[nodiscard]] std::optional<BufferInfo>
-    createBuffer(VkDeviceSize size,
-                 VkBufferUsageFlags usage,
-                 VmaAllocationCreateFlags flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                                                  VMA_ALLOCATION_CREATE_MAPPED_BIT,
-                 VkMemoryPropertyFlags requiredProperties = 0) const;
+    [[nodiscard]] std::optional<BufferInfo> createBuffer(VkDeviceSize size,
+                                                         VkBufferUsageFlags usage,
+                                                         VmaAllocationCreateFlags flags,
+                                                         VkMemoryPropertyFlags requiredProperties = 0) const;
+    [[nodiscard]] std::optional<ImageInfo> createImage(uint32_t width,
+                                                       uint32_t height,
+                                                       VkFormat format,
+                                                       VkImageTiling tiling,
+                                                       uint32_t mipLevels,
+                                                       VkImageUsageFlags usage,
+                                                       VmaAllocationCreateFlags flags,
+                                                       VkMemoryPropertyFlags requiredProperties = 0) const;
 
     /**
      * \brief Push a graphics command buffer to a list

--- a/includes/FastEngine/vulkan/C_context.hpp
+++ b/includes/FastEngine/vulkan/C_context.hpp
@@ -340,6 +340,13 @@ public:
      */
     [[nodiscard]] VmaAllocator getAllocator() const;
 
+    [[nodiscard]] std::optional<BufferInfo>
+    createBuffer(VkDeviceSize size,
+                 VkBufferUsageFlags usage,
+                 VmaAllocationCreateFlags flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                                                  VMA_ALLOCATION_CREATE_MAPPED_BIT,
+                 VkMemoryPropertyFlags requiredProperties = 0) const;
+
     /**
      * \brief Push a graphics command buffer to a list
      *

--- a/includes/FastEngine/vulkan/C_garbageCollector.hpp
+++ b/includes/FastEngine/vulkan/C_garbageCollector.hpp
@@ -66,13 +66,6 @@ struct GarbageDescriptorSet
 };
 struct GarbageBuffer
 {
-    [[deprecated("see BufferInfo")]] constexpr GarbageBuffer(VkBuffer buffer,
-                                                             VmaAllocation bufferAllocation,
-                                                             VmaAllocator allocator) :
-            _type(GarbageType::GARBAGE_VERTEX_BUFFER),
-            _bufferInfo(buffer, bufferAllocation),
-            _allocator(allocator)
-    {}
     constexpr GarbageBuffer(BufferInfo bufferInfo, VmaAllocator allocator) :
             _type(GarbageType::GARBAGE_VERTEX_BUFFER),
             _bufferInfo(bufferInfo),

--- a/includes/FastEngine/vulkan/C_garbageCollector.hpp
+++ b/includes/FastEngine/vulkan/C_garbageCollector.hpp
@@ -66,16 +66,21 @@ struct GarbageDescriptorSet
 };
 struct GarbageBuffer
 {
-    constexpr GarbageBuffer(VkBuffer buffer, VmaAllocation bufferAllocation, VmaAllocator allocator) :
+    [[deprecated("see BufferInfo")]] constexpr GarbageBuffer(VkBuffer buffer,
+                                                             VmaAllocation bufferAllocation,
+                                                             VmaAllocator allocator) :
             _type(GarbageType::GARBAGE_VERTEX_BUFFER),
-            _buffer(buffer),
-            _bufferAllocation(bufferAllocation),
+            _bufferInfo(buffer, bufferAllocation),
+            _allocator(allocator)
+    {}
+    constexpr GarbageBuffer(BufferInfo bufferInfo, VmaAllocator allocator) :
+            _type(GarbageType::GARBAGE_VERTEX_BUFFER),
+            _bufferInfo(bufferInfo),
             _allocator(allocator)
     {}
 
     GarbageType _type;
-    VkBuffer _buffer;
-    VmaAllocation _bufferAllocation;
+    BufferInfo _bufferInfo;
     VmaAllocator _allocator;
 };
 struct GarbageGraphicPipeline

--- a/includes/FastEngine/vulkan/C_logicalDevice.hpp
+++ b/includes/FastEngine/vulkan/C_logicalDevice.hpp
@@ -54,6 +54,8 @@ public:
     [[nodiscard]] VkQueue getPresentQueue() const;
     [[nodiscard]] VkPhysicalDeviceFeatures getEnabledFeatures() const;
 
+    [[nodiscard]] VkImageView createImageView(VkImage image, VkFormat format, uint32_t mipLevels) const;
+
 private:
     VkDevice g_device;
     VkQueue g_graphicQueue;

--- a/includes/FastEngine/vulkan/C_textureImage.hpp
+++ b/includes/FastEngine/vulkan/C_textureImage.hpp
@@ -81,8 +81,7 @@ public:
 private:
     void createTextureSampler(float mipLodBias, float mipLodMin, float mipLodMax);
 
-    VkImage g_textureImage;
-    VmaAllocation g_textureImageAllocation;
+    ImageInfo g_imageInfo;
 
     VkImageView g_textureImageView;
     VkSampler g_textureSampler;

--- a/includes/FastEngine/vulkan/C_uniformBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_uniformBuffer.hpp
@@ -62,10 +62,9 @@ public:
 
 private:
 #ifndef FGE_DEF_SERVER
-    void createBuffer(VkDeviceSize bufferSize, VkBuffer& buffer, VmaAllocation& bufferAllocation);
+    [[nodiscard]] BufferInfo createBuffer(VkDeviceSize bufferSize) const;
 
-    VkBuffer g_uniformBuffer;
-    VmaAllocation g_uniformBufferAllocation;
+    BufferInfo g_uniformBufferInfo;
     void* g_uniformBufferMapped;
     VkDeviceSize g_bufferSize;
     VkDeviceSize g_bufferCapacity;

--- a/includes/FastEngine/vulkan/C_vertexBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_vertexBuffer.hpp
@@ -88,8 +88,7 @@ private:
     std::vector<Vertex> g_vertices;
 
     mutable BufferInfo g_bufferInfo;
-    mutable VkBuffer g_stagingBuffer;
-    mutable VmaAllocation g_stagingBufferAllocation;
+    mutable BufferInfo g_stagingBufferInfo;
     mutable std::size_t g_bufferCapacity;
 
     mutable bool g_needUpdate;

--- a/includes/FastEngine/vulkan/C_vertexBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_vertexBuffer.hpp
@@ -139,10 +139,8 @@ private:
 
     std::vector<uint16_t> g_indices;
 
-    mutable VkBuffer g_buffer;
-    mutable VkBuffer g_stagingBuffer;
-    mutable VmaAllocation g_bufferAllocation;
-    mutable VmaAllocation g_stagingBufferAllocation;
+    mutable BufferInfo g_bufferInfo;
+    mutable BufferInfo g_stagingBufferInfo;
     mutable std::size_t g_bufferCapacity;
 
     mutable bool g_needUpdate;

--- a/includes/FastEngine/vulkan/C_vertexBuffer.hpp
+++ b/includes/FastEngine/vulkan/C_vertexBuffer.hpp
@@ -87,9 +87,8 @@ private:
 
     std::vector<Vertex> g_vertices;
 
-    mutable VkBuffer g_buffer;
+    mutable BufferInfo g_bufferInfo;
     mutable VkBuffer g_stagingBuffer;
-    mutable VmaAllocation g_bufferAllocation;
     mutable VmaAllocation g_stagingBufferAllocation;
     mutable std::size_t g_bufferCapacity;
 

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -58,6 +58,22 @@ struct BufferInfo
     }
 };
 
+struct ImageInfo
+{
+    VkImage _image{VK_NULL_HANDLE};
+    VmaAllocation _allocation{VK_NULL_HANDLE};
+
+    [[nodiscard]] inline constexpr bool valid() const
+    {
+        return this->_image != VK_NULL_HANDLE && this->_allocation != VK_NULL_HANDLE;
+    }
+    inline constexpr void clear()
+    {
+        this->_image = VK_NULL_HANDLE;
+        this->_allocation = VK_NULL_HANDLE;
+    }
+};
+
 FGE_API extern std::vector<char const*> InstanceLayers;
 FGE_API extern std::vector<char const*> DeviceExtensions;
 FGE_API extern std::vector<char const*> InstanceExtensions;
@@ -66,17 +82,6 @@ FGE_API extern Context& GetActiveContext();
 FGE_API extern void SetActiveContext(Context& context);
 
 FGE_API bool CheckInstanceLayerSupport(char const* layerName);
-
-FGE_API void CreateImage(Context const& context,
-                         uint32_t width,
-                         uint32_t height,
-                         VkFormat format,
-                         VkImageTiling tiling,
-                         VkImageUsageFlags usage,
-                         VkMemoryPropertyFlags properties,
-                         uint32_t mipLevels,
-                         VkImage& image,
-                         VmaAllocation& allocation);
 
 FGE_API VkImageView CreateImageView(LogicalDevice const& logicalDevice,
                                     VkImage image,

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -67,13 +67,6 @@ FGE_API extern void SetActiveContext(Context& context);
 
 FGE_API bool CheckInstanceLayerSupport(char const* layerName);
 
-[[deprecated("see Context::createBuffer()")]] FGE_API void CreateBuffer(Context const& context,
-                                                                        VkDeviceSize size,
-                                                                        VkBufferUsageFlags usage,
-                                                                        VkMemoryPropertyFlags properties,
-                                                                        VkBuffer& buffer,
-                                                                        VmaAllocation& allocation);
-
 FGE_API void CreateImage(Context const& context,
                          uint32_t width,
                          uint32_t height,

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -42,6 +42,22 @@ class LogicalDevice;
 class PhysicalDevice;
 class Context;
 
+struct BufferInfo
+{
+    VkBuffer _buffer{VK_NULL_HANDLE};
+    VmaAllocation _allocation{VK_NULL_HANDLE};
+
+    [[nodiscard]] inline constexpr bool valid() const
+    {
+        return this->_buffer != VK_NULL_HANDLE && this->_allocation != VK_NULL_HANDLE;
+    }
+    inline constexpr void clear()
+    {
+        this->_buffer = VK_NULL_HANDLE;
+        this->_allocation = VK_NULL_HANDLE;
+    }
+};
+
 FGE_API extern std::vector<char const*> InstanceLayers;
 FGE_API extern std::vector<char const*> DeviceExtensions;
 FGE_API extern std::vector<char const*> InstanceExtensions;
@@ -51,12 +67,12 @@ FGE_API extern void SetActiveContext(Context& context);
 
 FGE_API bool CheckInstanceLayerSupport(char const* layerName);
 
-FGE_API void CreateBuffer(Context const& context,
-                          VkDeviceSize size,
-                          VkBufferUsageFlags usage,
-                          VkMemoryPropertyFlags properties,
-                          VkBuffer& buffer,
-                          VmaAllocation& allocation);
+[[deprecated("see Context::createBuffer()")]] FGE_API void CreateBuffer(Context const& context,
+                                                                        VkDeviceSize size,
+                                                                        VkBufferUsageFlags usage,
+                                                                        VkMemoryPropertyFlags properties,
+                                                                        VkBuffer& buffer,
+                                                                        VmaAllocation& allocation);
 
 FGE_API void CreateImage(Context const& context,
                          uint32_t width,

--- a/includes/FastEngine/vulkan/vulkanGlobal.hpp
+++ b/includes/FastEngine/vulkan/vulkanGlobal.hpp
@@ -38,8 +38,6 @@
 namespace fge::vulkan
 {
 
-class LogicalDevice;
-class PhysicalDevice;
 class Context;
 
 struct BufferInfo
@@ -82,11 +80,6 @@ FGE_API extern Context& GetActiveContext();
 FGE_API extern void SetActiveContext(Context& context);
 
 FGE_API bool CheckInstanceLayerSupport(char const* layerName);
-
-FGE_API VkImageView CreateImageView(LogicalDevice const& logicalDevice,
-                                    VkImage image,
-                                    VkFormat format,
-                                    uint32_t mipLevels);
 
 } // namespace fge::vulkan
 

--- a/resources/shaders/objShapeInstances_vertex.vert
+++ b/resources/shaders/objShapeInstances_vertex.vert
@@ -11,7 +11,7 @@ struct TransformsData {
     mat4 modelTransform;
     mat4 viewTransform;
 };
-layout(set = 0, binding = 0) buffer GlobalTransformsData {
+layout(set = 0, binding = 0) buffer readonly GlobalTransformsData {
     TransformsData data[];
 } globalTransforms;
 
@@ -19,7 +19,7 @@ struct InstanceData {
     uvec4 color[2];
     vec2 offset;
 };
-layout(set = 1, binding = 0) buffer BufferInstanceData {
+layout(set = 1, binding = 0) buffer readonly BufferInstanceData {
     InstanceData data[];
 } instances;
 

--- a/resources/shaders/objSpriteBatches_vertex.vert
+++ b/resources/shaders/objSpriteBatches_vertex.vert
@@ -13,7 +13,7 @@ struct InstanceData {
     uint textureIndex;
 };
 
-layout(set = 0, binding = 0) buffer BufferInstanceData {
+layout(set = 0, binding = 0) buffer readonly BufferInstanceData {
     InstanceData data[];
 } instances;
 

--- a/sources/graphic/shaderResources.cpp
+++ b/sources/graphic/shaderResources.cpp
@@ -36,7 +36,7 @@ struct InstanceData {
     mat4 viewTransform;
 };
 
-layout(set = 0, binding = 0) buffer BufferInstanceData {
+layout(set = 0, binding = 0) buffer readonly BufferInstanceData {
     InstanceData data[];
 } instances;
 

--- a/sources/object/C_objSpriteBatches.cpp
+++ b/sources/object/C_objSpriteBatches.cpp
@@ -201,8 +201,7 @@ FGE_OBJ_DRAW_BODY(ObjSpriteBatches)
     auto* view = static_cast<InstanceDataBuffer*>(this->g_instancesTransform.getBufferMapped());
     view->_transform = target.getView().getProjection() * target.getView().getTransform();
 
-    auto globalTransformIndex = target.requestGlobalTransform(*this, states._resTransform);
-    fge::TransformUboData const* parentTransform = target.getContext().getGlobalTransform(globalTransformIndex);
+    fge::TransformUboData const* parentTransform = target.getGlobalTransform(states._resTransform);
 
     //Update all model matrices
     for (std::size_t i = 0; i < this->g_instancesData.size(); ++i)
@@ -210,8 +209,15 @@ FGE_OBJ_DRAW_BODY(ObjSpriteBatches)
         auto* instance = static_cast<InstanceDataBuffer*>(this->g_instancesTransform.getBufferMapped()) + i + 1;
 
         instance->_textureIndex = this->g_instancesData[i]._textureIndex;
-        instance->_transform =
-                parentTransform->_modelTransform * this->g_instancesData[i]._transformable.getTransform();
+        if (parentTransform != nullptr)
+        {
+            instance->_transform = parentTransform->_modelTransform * this->getTransform() *
+                                   this->g_instancesData[i]._transformable.getTransform();
+        }
+        else
+        {
+            instance->_transform = this->getTransform() * this->g_instancesData[i]._transformable.getTransform();
+        }
     }
 
     auto copyStates = states.copy();

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -548,6 +548,31 @@ VmaAllocator Context::getAllocator() const
 {
     return this->g_allocator;
 }
+std::optional<BufferInfo> Context::createBuffer(VkDeviceSize size,
+                                                VkBufferUsageFlags usage,
+                                                VmaAllocationCreateFlags flags,
+                                                VkMemoryPropertyFlags requiredProperties) const
+{
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = size;
+    bufferInfo.usage = usage;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocationCreateInfo{};
+    allocationCreateInfo.flags = flags;
+    allocationCreateInfo.requiredFlags = requiredProperties;
+    allocationCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    BufferInfo info{};
+    auto result = vmaCreateBuffer(this->getAllocator(), &bufferInfo, &allocationCreateInfo, &info._buffer,
+                                  &info._allocation, nullptr);
+    if (result != VK_SUCCESS)
+    {
+        return std::nullopt;
+    }
+    return info;
+}
 
 void Context::pushGraphicsCommandBuffer(VkCommandBuffer commandBuffer) const
 {

--- a/sources/vulkan/C_context.cpp
+++ b/sources/vulkan/C_context.cpp
@@ -573,6 +573,49 @@ std::optional<BufferInfo> Context::createBuffer(VkDeviceSize size,
     }
     return info;
 }
+std::optional<ImageInfo> Context::createImage(uint32_t width,
+                                              uint32_t height,
+                                              VkFormat format,
+                                              VkImageTiling tiling,
+                                              uint32_t mipLevels,
+                                              VkImageUsageFlags usage,
+                                              VmaAllocationCreateFlags flags,
+                                              VkMemoryPropertyFlags requiredProperties) const
+{
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.extent.width = width;
+    imageInfo.extent.height = height;
+    imageInfo.extent.depth = 1;
+    imageInfo.mipLevels = mipLevels;
+    imageInfo.arrayLayers = 1;
+
+    imageInfo.format = format;
+    imageInfo.tiling = tiling;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.usage = usage;
+
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.flags = 0; // Optional
+
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocationCreateInfo{};
+    allocationCreateInfo.flags = flags;
+    allocationCreateInfo.requiredFlags = requiredProperties;
+    allocationCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    ImageInfo info{};
+    auto result = vmaCreateImage(this->getAllocator(), &imageInfo, &allocationCreateInfo, &info._image,
+                                 &info._allocation, nullptr);
+
+    if (result != VK_SUCCESS)
+    {
+        return std::nullopt;
+    }
+    return info;
+}
 
 void Context::pushGraphicsCommandBuffer(VkCommandBuffer commandBuffer) const
 {

--- a/sources/vulkan/C_garbageCollector.cpp
+++ b/sources/vulkan/C_garbageCollector.cpp
@@ -31,8 +31,8 @@ Garbage::~Garbage()
                              &this->g_data._descriptorSet._descriptorSet);
         break;
     case GarbageType::GARBAGE_VERTEX_BUFFER:
-        vmaDestroyBuffer(this->g_data._buffer._allocator, this->g_data._buffer._buffer,
-                         this->g_data._buffer._bufferAllocation);
+        vmaDestroyBuffer(this->g_data._buffer._allocator, this->g_data._buffer._bufferInfo._buffer,
+                         this->g_data._buffer._bufferInfo._allocation);
         break;
     case GarbageType::GARBAGE_GRAPHIC_PIPELINE:
         vkDestroyPipeline(this->g_data._graphicPipeline._logicalDevice, this->g_data._graphicPipeline._pipeline,

--- a/sources/vulkan/C_logicalDevice.cpp
+++ b/sources/vulkan/C_logicalDevice.cpp
@@ -205,4 +205,25 @@ VkPhysicalDeviceFeatures LogicalDevice::getEnabledFeatures() const
     return this->g_enabledFeatures;
 }
 
+VkImageView LogicalDevice::createImageView(VkImage image, VkFormat format, uint32_t mipLevels) const
+{
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = image;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = format;
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = mipLevels;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    VkImageView imageView = VK_NULL_HANDLE;
+    if (vkCreateImageView(this->g_device, &viewInfo, nullptr, &imageView) != VK_SUCCESS)
+    {
+        return VK_NULL_HANDLE;
+    }
+    return imageView;
+}
+
 } // namespace fge::vulkan

--- a/sources/vulkan/C_swapChain.cpp
+++ b/sources/vulkan/C_swapChain.cpp
@@ -189,7 +189,7 @@ void SwapChain::createImageViews()
     for (size_t i = 0; i < this->g_swapChainImages.size(); i++)
     {
         this->g_swapChainImageViews[i] =
-                CreateImageView(*this->g_logicalDevice, this->g_swapChainImages[i], this->g_swapChainImageFormat, 1);
+                this->g_logicalDevice->createImageView(this->g_swapChainImages[i], this->g_swapChainImageFormat, 1);
     }
 }
 

--- a/sources/vulkan/C_textureImage.cpp
+++ b/sources/vulkan/C_textureImage.cpp
@@ -175,8 +175,8 @@ bool TextureImage::create(glm::vec<2, int> const& size, uint32_t levels)
 
     vmaDestroyBuffer(context.getAllocator(), stagingBufferInfo._buffer, stagingBufferInfo._allocation);
 
-    this->g_textureImageView = CreateImageView(context.getLogicalDevice(), this->g_imageInfo._image,
-                                               FGE_VULKAN_TEXTUREIMAGE_FORMAT, this->g_mipLevels);
+    this->g_textureImageView = context.getLogicalDevice().createImageView(
+            this->g_imageInfo._image, FGE_VULKAN_TEXTUREIMAGE_FORMAT, this->g_mipLevels);
 
     this->createTextureSampler(0.0f, 0.0f, static_cast<float>(this->g_mipLevels));
 
@@ -245,8 +245,8 @@ bool TextureImage::create(SDL_Surface* surface, uint32_t levels)
 
     vmaDestroyBuffer(context.getAllocator(), stagingBufferInfo._buffer, stagingBufferInfo._allocation);
 
-    this->g_textureImageView = CreateImageView(context.getLogicalDevice(), this->g_imageInfo._image,
-                                               FGE_VULKAN_TEXTUREIMAGE_FORMAT, this->g_mipLevels);
+    this->g_textureImageView = context.getLogicalDevice().createImageView(
+            this->g_imageInfo._image, FGE_VULKAN_TEXTUREIMAGE_FORMAT, this->g_mipLevels);
 
     this->createTextureSampler(0.0f, 0.0f, static_cast<float>(this->g_mipLevels));
 

--- a/sources/vulkan/C_vertexBuffer.cpp
+++ b/sources/vulkan/C_vertexBuffer.cpp
@@ -350,9 +350,7 @@ void VertexBuffer::cleanBuffer() const
 #ifndef FGE_DEF_SERVER
     if (this->g_type != BufferTypes::UNINITIALIZED)
     {
-        //TODO: use Context::BufferInfo in the GarbageCollector
-        this->getContext()._garbageCollector.push(fge::vulkan::GarbageBuffer(
-                this->g_bufferInfo._buffer, this->g_bufferInfo._allocation, this->getContext().getAllocator()));
+        this->getContext()._garbageCollector.push(GarbageBuffer(this->g_bufferInfo, this->getContext().getAllocator()));
         this->g_bufferInfo.clear();
 
         if (this->g_type == BufferTypes::DEVICE)

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -85,51 +85,6 @@ bool CheckInstanceLayerSupport(char const* layerName)
     return false;
 }
 
-void CreateImage(Context const& context,
-                 uint32_t width,
-                 uint32_t height,
-                 VkFormat format,
-                 VkImageTiling tiling,
-                 VkImageUsageFlags usage,
-                 VkMemoryPropertyFlags properties,
-                 uint32_t mipLevels,
-                 VkImage& image,
-                 VmaAllocation& allocation)
-{
-    VkImageCreateInfo imageInfo{};
-    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    imageInfo.imageType = VK_IMAGE_TYPE_2D;
-    imageInfo.extent.width = width;
-    imageInfo.extent.height = height;
-    imageInfo.extent.depth = 1;
-    imageInfo.mipLevels = mipLevels;
-    imageInfo.arrayLayers = 1;
-
-    imageInfo.format = format;
-    imageInfo.tiling = tiling;
-    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    imageInfo.usage = usage;
-
-    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-    imageInfo.flags = 0; // Optional
-
-    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VmaAllocationCreateInfo allocationCreateInfo{};
-    allocationCreateInfo.flags =
-            VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
-    allocationCreateInfo.requiredFlags = properties;
-    allocationCreateInfo.usage = VMA_MEMORY_USAGE_UNKNOWN;
-
-    auto result =
-            vmaCreateImage(context.getAllocator(), &imageInfo, &allocationCreateInfo, &image, &allocation, nullptr);
-
-    if (result != VK_SUCCESS)
-    {
-        throw fge::Exception("failed to create image!");
-    }
-}
-
 VkImageView CreateImageView(LogicalDevice const& logicalDevice, VkImage image, VkFormat format, uint32_t mipLevels)
 {
     VkImageViewCreateInfo viewInfo{};

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -85,34 +85,6 @@ bool CheckInstanceLayerSupport(char const* layerName)
     return false;
 }
 
-void CreateBuffer(Context const& context,
-                  VkDeviceSize size,
-                  VkBufferUsageFlags usage,
-                  VkMemoryPropertyFlags properties,
-                  VkBuffer& buffer,
-                  VmaAllocation& allocation)
-{
-    VkBufferCreateInfo bufferInfo{};
-    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufferInfo.size = size;
-    bufferInfo.usage = usage;
-    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VmaAllocationCreateInfo allocationCreateInfo{};
-    allocationCreateInfo.flags =
-            VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
-    allocationCreateInfo.requiredFlags = properties;
-    allocationCreateInfo.usage = VMA_MEMORY_USAGE_UNKNOWN;
-
-    auto result =
-            vmaCreateBuffer(context.getAllocator(), &bufferInfo, &allocationCreateInfo, &buffer, &allocation, nullptr);
-
-    if (result != VK_SUCCESS)
-    {
-        throw fge::Exception("failed to create buffer!");
-    }
-}
-
 void CreateImage(Context const& context,
                  uint32_t width,
                  uint32_t height,

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -34,8 +34,8 @@ std::vector<char const*> InstanceLayers = {"VK_LAYER_KHRONOS_validation", "VK_LA
 std::vector<char const*> InstanceLayers = {};
 #endif
 
-std::vector<char const*> DeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                                             VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME};
+std::vector<char const*> DeviceExtensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+                                             VK_EXT_ROBUSTNESS_2_EXTENSION_NAME};
 
 std::vector<char const*> InstanceExtensions = {};
 

--- a/sources/vulkan/vulkanGlobal.cpp
+++ b/sources/vulkan/vulkanGlobal.cpp
@@ -17,8 +17,6 @@
 #include "FastEngine/vulkan/vulkanGlobal.hpp"
 #include "FastEngine/fge_except.hpp"
 #include "FastEngine/vulkan/C_context.hpp"
-#include "FastEngine/vulkan/C_logicalDevice.hpp"
-#include "FastEngine/vulkan/C_physicalDevice.hpp"
 #include <cstring>
 
 extern "C" {
@@ -83,28 +81,6 @@ bool CheckInstanceLayerSupport(char const* layerName)
         }
     }
     return false;
-}
-
-VkImageView CreateImageView(LogicalDevice const& logicalDevice, VkImage image, VkFormat format, uint32_t mipLevels)
-{
-    VkImageViewCreateInfo viewInfo{};
-    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    viewInfo.image = image;
-    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = format;
-    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    viewInfo.subresourceRange.baseMipLevel = 0;
-    viewInfo.subresourceRange.levelCount = mipLevels;
-    viewInfo.subresourceRange.baseArrayLayer = 0;
-    viewInfo.subresourceRange.layerCount = 1;
-
-    VkImageView imageView = VK_NULL_HANDLE;
-    if (vkCreateImageView(logicalDevice.getDevice(), &viewInfo, nullptr, &imageView) != VK_SUCCESS)
-    {
-        throw fge::Exception("failed to create texture image view!");
-    }
-
-    return imageView;
 }
 
 } // namespace fge::vulkan


### PR DESCRIPTION
Move CreateImage() CreateBuffer() to Context class:
- Avoid hardcoding VMA flags
- - Most notable change is that buffer don't use anymore the VMA_ALLOCATION_CREATE_MAPPED_BIT
- Use VMA_MEMORY_USAGE_AUTO instead of unknown
- Apply this change to codebase

VertexBuffer DEVICE mode:
- Use indirect command buffer execution

Add missing VK_EXT_ROBUSTNESS_2_EXTENSION_NAME.

Shaders: add missing "readonly" decoration
- This mute validation error : "vertexPipelineStoresAndAtomics was not enabled."

Move CreateImageView() to LogicalDevice

