### PR TITLE
Detached child objects

### DIFF
--- a/includes/FastEngine/C_callback.hpp
+++ b/includes/FastEngine/C_callback.hpp
@@ -342,6 +342,7 @@ private:
 
         CalleePtr _f;
         fge::Subscriber* _subscriber = nullptr;
+        bool _markedForDeletion = false;
     };
     using CalleeList = std::vector<CalleeData>;
 

--- a/includes/FastEngine/C_scene.hpp
+++ b/includes/FastEngine/C_scene.hpp
@@ -145,7 +145,8 @@ using DefaultSIDRanges_t = std::underlying_type_t<DefaultSIDRanges>;
 
 enum ObjectContextFlags : uint32_t
 {
-    OBJ_CONTEXT_NETWORK = 1 << 0, ///< The object is coming from the network
+    OBJ_CONTEXT_NETWORK = 1 << 0,  ///< The object is coming from the network
+    OBJ_CONTEXT_DETACHED = 1 << 1, ///< The object is a detached child to another object
 
     OBJ_CONTEXT_NONE = 0,
     OBJ_CONTEXT_DEFAULT = OBJ_CONTEXT_NONE
@@ -380,6 +381,7 @@ private:
     bool g_requireForceClientsCheckup;
 
     friend class fge::Scene;
+    friend class fge::ChildObjectsAccessor;
 };
 
 using ObjectDataWeak = std::weak_ptr<fge::ObjectData>;
@@ -480,7 +482,7 @@ public:
     explicit Scene(std::string sceneName);
     Scene(Scene const& r);
     Scene(Scene&& r) noexcept = delete; //TODO: implement move constructor
-    virtual ~Scene() = default;
+    virtual ~Scene();
 
     Scene& operator=(Scene const& r);
     Scene& operator=(Scene&& r) noexcept = delete; //TODO: implement move operator

--- a/includes/FastEngine/object/C_childObjectsAccessor.hpp
+++ b/includes/FastEngine/object/C_childObjectsAccessor.hpp
@@ -94,6 +94,26 @@ private:
     fge::Object* g_owner{nullptr};
 };
 
+template<class TObject>
+class DeclareChild
+{
+public:
+    constexpr DeclareChild(fge::Object* owner, std::size_t insertionIndex = std::numeric_limits<std::size_t>::max()) :
+            g_object(owner)
+    {
+        this->g_object._children.addExistingObject(&this->g_object, insertionIndex);
+    }
+
+    [[nodiscard]] constexpr TObject* operator->() { return &this->g_object; }
+    [[nodiscard]] constexpr TObject const* operator->() const { return &this->g_object; }
+
+    [[nodiscard]] constexpr TObject& get() { return this->g_object; }
+    [[nodiscard]] constexpr TObject const& get() const { return this->g_object; }
+
+private:
+    TObject g_object;
+};
+
 } // namespace fge
 
 #endif // _FGE_C_CHILDOBJECTSACCESSOR_HPP_INCLUDED

--- a/includes/tinyutf8.h
+++ b/includes/tinyutf8.h
@@ -2374,10 +2374,11 @@ namespace tiny_utf8
 		bool starts_with( const value_type (&str)[LITLEN] ) const noexcept {
 			size_type		str_len = str[LITLEN-1] ? LITLEN : LITLEN-1;
 			const_iterator	it = cbegin(), end = cend();
+		    value_type const* str_ptr = str;
 			while( it != end && str_len ){
-				if( *it != *str )
+				if( *it != *str_ptr )
 					return false;
-				++it, ++str, --str_len;
+				++it, ++str_ptr, --str_len;
 			}
 			return !str_len;
 		}

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -188,6 +188,10 @@ Scene::Scene(Scene const& r) :
 
     this->g_updatedObjectIterator = this->g_objects.end();
 }
+Scene::~Scene()
+{
+    this->clear();
+}
 
 Scene& Scene::operator=(Scene const& r)
 {

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -439,52 +439,9 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectPtr&& newObject,
                                        bool silent,
                                        fge::EnumFlags<ObjectContextFlags> contextFlags)
 {
-    if (newObject == nullptr)
-    {
-        return nullptr;
-    }
-    fge::ObjectSid generatedSid = this->generateSid(sid, type);
-    if (generatedSid == FGE_SCENE_BAD_SID)
-    {
-        return nullptr;
-    }
-    if (this->g_enableNetworkEventsFlag)
-    {
-        this->pushEvent({fge::SceneNetEvent::Events::OBJECT_CREATED, generatedSid});
-    }
-
-    auto it = this->hash_getInsertionIteratorFromPlanDataMap(plan);
-
-    it = this->g_objects.insert(
-            it, std::make_shared<fge::ObjectData>(this, std::move(newObject), generatedSid, plan, type));
-    (*it)->g_object->_myObjectData = *it;
-    (*it)->g_contextFlags = contextFlags;
-    if (!this->g_objectsHashMap.newObject(generatedSid, it))
-    {
-        //Something went wrong, we can do a re-map
-        this->g_objectsHashMap.reMap(this->g_objects);
-    }
-    this->hash_updatePlanDataMap(plan, it, false);
-
-    if (this->g_updatedObjectIterator != this->g_objects.end() && (*it)->g_parent.expired())
-    { //An object is created inside another object and orphan, make it parent
-        (*it)->g_parent = *this->g_updatedObjectIterator;
-    }
-    if (!silent)
-    {
-        (*it)->g_object->first(*this);
-    }
-
-    if ((*it)->g_object->_callbackContextMode == fge::Object::CallbackContextModes::CONTEXT_AUTO &&
-        this->g_callbackContext._event != nullptr && !silent)
-    {
-        (*it)->g_object->callbackRegister(*this->g_callbackContext._event, this->g_callbackContext._guiElementHandler);
-    }
-
-    this->_onObjectAdded.call(*this, *it);
-    this->_onPlanUpdate.call(*this, plan);
-
-    return *it;
+    auto newObjectData = std::make_shared<fge::ObjectData>(this, std::move(newObject), sid, plan, type);
+    newObjectData->g_contextFlags = contextFlags;
+    return this->newObject(std::move(newObjectData), silent);
 }
 fge::ObjectDataShared Scene::newObject(fge::ObjectDataShared const& objectData, bool silent)
 {

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -475,6 +475,12 @@ fge::ObjectDataShared Scene::newObject(fge::ObjectDataShared const& objectData, 
     }
     if (!silent)
     {
+        //make sure every created children have the correct owner ObjectData
+        for (std::size_t i = 0; i < objectData->g_object->_children.getSize(); ++i)
+        {
+            objectData->g_object->_children.getSharedPtr(i)->setParent(objectData);
+        }
+
         objectData->g_object->first(*this);
     }
 

--- a/sources/C_scene.cpp
+++ b/sources/C_scene.cpp
@@ -357,6 +357,17 @@ void Scene::draw(fge::RenderTarget& target, fge::RenderStates const& states) con
         {
             object->_children.draw(target, states);
         }
+
+        if ((*objectIt)->g_contextFlags.has(ObjectContextFlags::OBJ_CONTEXT_DETACHED) &&
+            !(*objectIt)->g_parent.expired())
+        {
+            auto const parent = (*objectIt)->g_parent.lock();
+            auto copyStates = states.copy();
+            copyStates._resTransform.set(target.requestGlobalTransform(*parent->g_object, states._resTransform));
+            object->draw(target, copyStates);
+            continue;
+        }
+
         object->draw(target, states);
     }
 

--- a/sources/network/C_server.cpp
+++ b/sources/network/C_server.cpp
@@ -1220,6 +1220,7 @@ ClientSideNetUdp::ClientSideNetUdp(IpAddress::Types addressType) :
         g_socket(addressType)
 {
     this->_client.getStatus().setNetworkStatus(ClientStatus::NetworkStatus::DISCONNECTED);
+    this->resetReturnPacket();
 }
 
 ClientSideNetUdp::~ClientSideNetUdp()

--- a/sources/object/C_childObjectsAccessor.cpp
+++ b/sources/object/C_childObjectsAccessor.cpp
@@ -29,36 +29,58 @@ void ChildObjectsAccessor::DataContext::NotHandledObjectDeleter::operator()(fge:
 ChildObjectsAccessor::ChildObjectsAccessor(fge::Object* owner) :
         g_owner(owner)
 {}
+ChildObjectsAccessor::~ChildObjectsAccessor()
+{
+    this->clear();
+}
 
 void ChildObjectsAccessor::clear()
 {
     this->g_data.clear();
+    this->clearDetachedObjects();
+}
+void ChildObjectsAccessor::clearDetachedObjects()
+{
+    for (std::size_t i = 0; i < this->g_detachedObjects.size(); ++i)
+    {
+        if (auto object = this->g_detachedObjects[i].lock())
+        {
+            if (object->getScene() == nullptr)
+            {
+                continue;
+            }
+
+            object->getScene()->delObject(object->getSid());
+        }
+    }
+    this->g_detachedObjects.clear();
 }
 
 fge::ObjectDataShared ChildObjectsAccessor::addExistingObject(fge::Object* object, std::size_t insertionIndex)
 {
     fge::Scene* linkedScene = nullptr;
     auto owner = this->g_owner->_myObjectData.lock();
+    fge::ObjectSid ownerSid = FGE_SCENE_BAD_SID;
     if (owner)
     {
         linkedScene = owner->getScene();
+        ownerSid = owner->getSid();
     }
 
     std::vector<DataContext>::iterator it;
     if (insertionIndex >= this->g_data.size())
     {
-        it = this->g_data.insert(this->g_data.end(),
-                                 {object, fge::ObjectDataShared{new fge::ObjectData{linkedScene, fge::ObjectPtr{object},
-                                                                                    owner->getSid()},
-                                                                DataContext::NotHandledObjectDeleter{}}});
+        it = this->g_data.insert(
+                this->g_data.end(),
+                {object, fge::ObjectDataShared{new fge::ObjectData{linkedScene, fge::ObjectPtr{object}, ownerSid},
+                                               DataContext::NotHandledObjectDeleter{}}});
     }
     else
     {
         it = this->g_data.insert(
                 this->g_data.begin() + static_cast<std::vector<DataContext>::difference_type>(insertionIndex),
-                {object,
-                 fge::ObjectDataShared{new fge::ObjectData{linkedScene, fge::ObjectPtr{object}, owner->getSid()},
-                                       DataContext::NotHandledObjectDeleter{}}});
+                {object, fge::ObjectDataShared{new fge::ObjectData{linkedScene, fge::ObjectPtr{object}, ownerSid},
+                                               DataContext::NotHandledObjectDeleter{}}});
     }
 
     it->_objData->setParent(owner);
@@ -75,24 +97,25 @@ fge::ObjectDataShared ChildObjectsAccessor::addNewObject(fge::ObjectPtr&& newObj
 {
     fge::Scene* linkedScene = nullptr;
     auto owner = this->g_owner->_myObjectData.lock();
+    fge::ObjectSid ownerSid = FGE_SCENE_BAD_SID;
     if (owner)
     {
         linkedScene = owner->getScene();
+        ownerSid = owner->getSid();
     }
 
     std::vector<DataContext>::iterator it;
     if (insertionIndex >= this->g_data.size())
     {
-        it = this->g_data.insert(this->g_data.end(),
-                                 {newObject.get(), std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject),
-                                                                                     owner->getSid())});
+        it = this->g_data.insert(
+                this->g_data.end(),
+                {newObject.get(), std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject), ownerSid)});
     }
     else
     {
         it = this->g_data.insert(
                 this->g_data.begin() + static_cast<std::vector<DataContext>::difference_type>(insertionIndex),
-                {newObject.get(),
-                 std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject), owner->getSid())});
+                {newObject.get(), std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject), ownerSid)});
     }
 
     it->_objData->setParent(owner);
@@ -104,6 +127,94 @@ fge::ObjectDataShared ChildObjectsAccessor::addNewObject(fge::ObjectPtr&& newObj
     }
 
     return it->_objData;
+}
+
+fge::ObjectDataShared ChildObjectsAccessor::addExistingDetachedObject(fge::Object* object,
+                                                                      fge::ObjectPlan newPlan) const
+{
+    this->cleanupDetachedObjects();
+    if (!object->_myObjectData.expired())
+    { // The object is assumed already detached
+        return object->_myObjectData.lock();
+    }
+
+    fge::Scene* linkedScene = nullptr;
+    auto owner = this->g_owner->_myObjectData.lock();
+    if (owner)
+    {
+        linkedScene = owner->getScene();
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    fge::ObjectDataShared detachedData{
+            new fge::ObjectData{linkedScene, fge::ObjectPtr{object}, FGE_SCENE_BAD_SID, newPlan},
+            DataContext::NotHandledObjectDeleter{}};
+
+    detachedData->setParent(owner);
+    detachedData->g_contextFlags = OBJ_CONTEXT_DETACHED;
+
+    this->g_detachedObjects.emplace_back(detachedData);
+
+    return linkedScene->newObject(detachedData, false);
+}
+fge::ObjectDataShared ChildObjectsAccessor::addNewDetachedObject(fge::ObjectPtr&& newObject,
+                                                                 fge::ObjectPlan newPlan) const
+{
+    this->cleanupDetachedObjects();
+    fge::Scene* linkedScene = nullptr;
+    auto owner = this->g_owner->_myObjectData.lock();
+    if (owner)
+    {
+        linkedScene = owner->getScene();
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    auto detachedData =
+            std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject), FGE_SCENE_BAD_SID, newPlan);
+
+    detachedData->setParent(owner);
+    detachedData->g_contextFlags = OBJ_CONTEXT_DETACHED;
+
+    this->g_detachedObjects.emplace_back(detachedData);
+
+    return linkedScene->newObject(detachedData, false);
+}
+
+bool ChildObjectsAccessor::detachObject(std::size_t index, fge::ObjectPlan newPlan)
+{
+    this->cleanupDetachedObjects();
+    if (index >= this->g_data.size())
+    {
+        return false;
+    }
+
+    fge::Scene* linkedScene = nullptr;
+    auto owner = this->g_owner->_myObjectData.lock();
+    if (owner)
+    {
+        linkedScene = owner->getScene();
+    }
+    else
+    {
+        return false;
+    }
+
+    auto dataObject = std::move(this->g_data[index]._objData);
+    this->g_data.erase(this->g_data.begin() + static_cast<std::vector<DataContext>::difference_type>(index));
+
+    dataObject->g_sid = FGE_SCENE_BAD_SID; // Can't have the same SID as the parent as it's now detached
+    dataObject->g_contextFlags = OBJ_CONTEXT_DETACHED;
+    dataObject->g_plan = newPlan;
+
+    linkedScene->newObject(dataObject, true);
+    this->g_detachedObjects.emplace_back(std::move(dataObject));
+    return true;
 }
 
 std::size_t ChildObjectsAccessor::getSize() const
@@ -205,6 +316,21 @@ std::size_t ChildObjectsAccessor::getIndex(fge::Object* object) const
         }
     }
     return std::numeric_limits<std::size_t>::max();
+}
+
+void ChildObjectsAccessor::cleanupDetachedObjects() const
+{
+    for (std::size_t i = 0; i < this->g_detachedObjects.size();)
+    {
+        if (this->g_detachedObjects[i].expired())
+        {
+            this->g_detachedObjects.erase(this->g_detachedObjects.begin() +
+                                          static_cast<std::vector<fge::ObjectDataWeak>::difference_type>(i));
+            --i;
+            continue;
+        }
+        ++i;
+    }
 }
 
 } // namespace fge

--- a/sources/object/C_childObjectsAccessor.cpp
+++ b/sources/object/C_childObjectsAccessor.cpp
@@ -126,6 +126,8 @@ fge::ObjectDataShared ChildObjectsAccessor::addNewObject(fge::ObjectPtr&& newObj
         it->_objPtr->first(*linkedScene);
     }
 
+    this->g_detachedObjects.emplace_back(it->_objData);
+
     return it->_objData;
 }
 
@@ -154,7 +156,7 @@ fge::ObjectDataShared ChildObjectsAccessor::addExistingDetachedObject(fge::Objec
             DataContext::NotHandledObjectDeleter{}};
 
     detachedData->setParent(owner);
-    detachedData->g_contextFlags = OBJ_CONTEXT_DETACHED;
+    detachedData->g_contextFlags.set(OBJ_CONTEXT_DETACHED);
 
     this->g_detachedObjects.emplace_back(detachedData);
 
@@ -179,7 +181,7 @@ fge::ObjectDataShared ChildObjectsAccessor::addNewDetachedObject(fge::ObjectPtr&
             std::make_shared<fge::ObjectData>(linkedScene, std::move(newObject), FGE_SCENE_BAD_SID, newPlan);
 
     detachedData->setParent(owner);
-    detachedData->g_contextFlags = OBJ_CONTEXT_DETACHED;
+    detachedData->g_contextFlags.set(OBJ_CONTEXT_DETACHED);
 
     this->g_detachedObjects.emplace_back(detachedData);
 
@@ -209,7 +211,7 @@ bool ChildObjectsAccessor::detachObject(std::size_t index, fge::ObjectPlan newPl
     this->g_data.erase(this->g_data.begin() + static_cast<std::vector<DataContext>::difference_type>(index));
 
     dataObject->g_sid = FGE_SCENE_BAD_SID; // Can't have the same SID as the parent as it's now detached
-    dataObject->g_contextFlags = OBJ_CONTEXT_DETACHED;
+    dataObject->g_contextFlags.set(OBJ_CONTEXT_DETACHED);
     dataObject->g_plan = newPlan;
 
     linkedScene->newObject(dataObject, true);


### PR DESCRIPTION
Basically allow children of object to become "detached" (an entire independent object in the scene).
It's really useful when a child have to be in another plan than the parent.

Copilot:

This pull request introduces significant improvements to the handling of child objects and callbacks within the engine, focusing on safer object detachment, better memory management, and improved callback handling. The changes include new mechanisms to manage detached child objects, enhancements to the callback system to avoid undefined behavior, and several bug fixes and code cleanups.

**Child Object Management and Detachment:**

* Added support for marking objects as "detached" children via the new `OBJ_CONTEXT_DETACHED` flag in `ObjectContextFlags`, and updated the drawing logic to handle detached children correctly. [[1]](diffhunk://#diff-bf610c8fb4415e2d9853abcc4d1ae9063f1d3171e8291870ff391277eb6bc083R149) [[2]](diffhunk://#diff-c4f04dba364289c5e827bd912629e96e6d8c0512a28b800be28ef72719da6b34R360-R370)
* Introduced new methods in `ChildObjectsAccessor` for adding, detaching, and clearing detached objects, along with a new `g_detachedObjects` container to track them. Added a destructor to ensure proper cleanup. [[1]](diffhunk://#diff-d8e31f264d8d884105b059c2f96d597b64ebe0e7e877dcd6ab0c66ef19c30786R40-R65) [[2]](diffhunk://#diff-d8e31f264d8d884105b059c2f96d597b64ebe0e7e877dcd6ab0c66ef19c30786R100-R134) [[3]](diffhunk://#diff-d2b6577e58c56518e7b95bbfdbf8cb061e4432c80650a6dc1bb48c55493d9f4bR32-R82)
* Modified `addExistingObject` and `addNewObject` in `ChildObjectsAccessor` to handle owner SIDs more robustly and ensure correct parent assignment for children. [[1]](diffhunk://#diff-d2b6577e58c56518e7b95bbfdbf8cb061e4432c80650a6dc1bb48c55493d9f4bR32-R82) [[2]](diffhunk://#diff-d2b6577e58c56518e7b95bbfdbf8cb061e4432c80650a6dc1bb48c55493d9f4bR100-R118) [[3]](diffhunk://#diff-c4f04dba364289c5e827bd912629e96e6d8c0512a28b800be28ef72719da6b34R489-R494)

**Callback System Improvements:**

* Replaced the use of `nullptr` with a `_markedForDeletion` flag in `CallbackHandler` to prevent undefined behavior when callbacks remove themselves during execution, and updated all relevant methods to use this flag. [[1]](diffhunk://#diff-efdbd46484a6d8111e3fdb30f241a71c474779eff71107f223b7b77fd26f7b51R345) [[2]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL105-R105) [[3]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL119-R126) [[4]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL164-R176) [[5]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL182-R186) [[6]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL191-R198) [[7]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL204-R216) [[8]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL225-R229) [[9]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL241-R246) [[10]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL266-R277)

**Scene and Object Lifecycle Enhancements:**

* Implemented a custom destructor for `Scene` to ensure all objects are cleared on destruction, and refactored object creation to use a more consistent approach with `ObjectDataShared`. [[1]](diffhunk://#diff-bf610c8fb4415e2d9853abcc4d1ae9063f1d3171e8291870ff391277eb6bc083L483-R485) [[2]](diffhunk://#diff-c4f04dba364289c5e827bd912629e96e6d8c0512a28b800be28ef72719da6b34R191-R194) [[3]](diffhunk://#diff-c4f04dba364289c5e827bd912629e96e6d8c0512a28b800be28ef72719da6b34L438-R455)
* Ensured that child objects have their parent pointers correctly set after creation, improving scene graph consistency.

**Miscellaneous Fixes and Improvements:**

* Fixed a bug in `tiny_utf8::starts_with` by using a separate pointer for string comparison.
* Ensured that network client status is reset properly on creation.

These changes collectively improve the robustness, safety, and maintainability of the engine's core object and callback handling systems.