### PR TITLE
Unique callback handler

### DIFF
--- a/examples/clientServerLifeSimulator_004/server/main.cpp
+++ b/examples/clientServerLifeSimulator_004/server/main.cpp
@@ -142,7 +142,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[])
     });
 
     //Handling clients return packet
-    serverFlux->_onClientReturnPacket.addLambda([](fge::net::ClientSharedPtr const& client, fge::net::Identity id,
+    serverFlux->_onClientReturnPacket.setLambda([](fge::net::ClientSharedPtr const& client, fge::net::Identity id,
                                                    fge::net::ReceivedPacketPtr const& packet) {
         std::cout << "received update from : " << packet->getIdentity().toString() << std::endl;
 

--- a/includes/FastEngine/C_callback.hpp
+++ b/includes/FastEngine/C_callback.hpp
@@ -362,10 +362,10 @@ private:
  * \tparam Types The list of arguments types passed to the callbacks
  */
 template<class... Types>
-class UniqueCallbackHandler : public fge::Subscription
+class UniqueCallbackHandler : public fge::UniqueSubscription
 {
 public:
-    using CalleePtr = CalleeUniquePtr<Types...>;
+    using CalleePtr = CalleeUniquePtr<void, Types...>;
 
     UniqueCallbackHandler() = default;
     ~UniqueCallbackHandler() override = default;
@@ -374,7 +374,8 @@ public:
      * \brief Copy constructor that does nothing
      */
     UniqueCallbackHandler([[maybe_unused]] fge::UniqueCallbackHandler<Types...> const& n) :
-            fge::Subscription() {}
+            fge::UniqueSubscription()
+    {}
     /**
      * \brief Move constructor prohibited
      */
@@ -403,7 +404,7 @@ public:
      * \param subscriber The subscriber to use to categorize the callback
      * \return The callback pointer
      */
-    inline fge::CallbackBase<Types...>* set(CalleePtr&& callback, fge::Subscriber* subscriber = nullptr);
+    inline fge::CallbackBase<void, Types...>* set(CalleePtr&& callback, fge::Subscriber* subscriber = nullptr);
 
     /**
      * \brief Helper method to set a callback functor
@@ -414,8 +415,9 @@ public:
      * \param subscriber The subscriber to use to categorize the callback
      * \return The callback pointer
      */
-    inline fge::CallbackFunctor<Types...>* setFunctor(typename fge::CallbackFunctor<Types...>::CallbackFunction func,
-                                                      fge::Subscriber* subscriber = nullptr);
+    inline fge::CallbackFunctor<void, Types...>*
+    setFunctor(typename fge::CallbackFunctor<void, Types...>::CallbackFunction func,
+               fge::Subscriber* subscriber = nullptr);
     /**
      * \brief Helper method to set a callback lambda
      *
@@ -427,7 +429,7 @@ public:
      * \return The callback pointer
      */
     template<typename TLambda>
-    inline fge::CallbackLambda<Types...>* setLambda(TLambda const& lambda, fge::Subscriber* subscriber = nullptr);
+    inline fge::CallbackLambda<void, Types...>* setLambda(TLambda const& lambda, fge::Subscriber* subscriber = nullptr);
     /**
      * \brief Helper method to set a callback object functor
      *
@@ -440,8 +442,8 @@ public:
      * \return The callback pointer
      */
     template<class TObject>
-    inline fge::CallbackObjectFunctor<TObject, Types...>*
-    setObjectFunctor(typename fge::CallbackObjectFunctor<TObject, Types...>::CallbackFunctionObject func,
+    inline fge::CallbackObjectFunctor<void, TObject, Types...>*
+    setObjectFunctor(typename fge::CallbackObjectFunctor<void, TObject, Types...>::CallbackFunctionObject func,
                      TObject* object,
                      Subscriber* subscriber = nullptr);
 
@@ -493,7 +495,7 @@ private:
         fge::Subscriber* _subscriber = nullptr;
     };
 
-    CalleeData g_callee;
+    CalleeData g_callee{nullptr, nullptr};
 
     mutable std::recursive_mutex g_mutex;
 };

--- a/includes/FastEngine/C_callback.hpp
+++ b/includes/FastEngine/C_callback.hpp
@@ -170,6 +170,61 @@ template<class TReturn, class... Types>
 using CalleeSharedPtr = std::shared_ptr<fge::CallbackBase<TReturn, Types...>>;
 
 /**
+ * \struct CallbackStaticHelpers
+ * \ingroup callback
+ * \brief This struct helper is used to create callbacks
+ *
+ * \tparam TCalleePtr The callback pointer type, can be CalleeUniquePtr or CalleeSharedPtr
+ * \tparam Types The list of arguments types passed to the functor
+ */
+template<class TReturn, class TCalleePtr, class... Types>
+struct CallbackStaticHelpers
+{
+    using CalleePtr = TCalleePtr;
+
+    /**
+     * \brief Helper function to create a new callback functor
+     *
+     * \param func The callback function
+     * \return The callback pointer
+     */
+    [[nodiscard]] inline static CalleePtr
+    newFunctor(typename fge::CallbackFunctor<TReturn, Types...>::CallbackFunction func)
+    {
+        return CalleePtr{new fge::CallbackFunctor<TReturn, Types...>(func)};
+    }
+
+    /**
+     * \brief Helper function to create a new callback lambda
+     *
+     * \tparam TLambda The lambda type
+     * \param lambda The callback lambda
+     * \return The callback pointer
+     */
+    template<typename TLambda>
+    [[nodiscard]] inline static CalleePtr newLambda(TLambda const& lambda)
+    {
+        return CalleePtr{new fge::CallbackLambda<TReturn, Types...>(lambda)};
+    }
+
+    /**
+     * \brief Helper function to create a new callback object functor
+     *
+     * \tparam TObject The object type
+     * \param func The callback method of the object
+     * \param object The object pointer
+     * \return The callback pointer
+     */
+    template<class TObject>
+    [[nodiscard]] inline static CalleePtr
+    newObjectFunctor(typename fge::CallbackObjectFunctor<TReturn, TObject, Types...>::CallbackFunctionObject func,
+                     TObject* object)
+    {
+        return CalleePtr{new fge::CallbackObjectFunctor<TReturn, TObject, Types...>(func, object)};
+    }
+};
+
+/**
  * \class CallbackHandler
  * \ingroup callback
  * \brief This class is used to handle callbacks in a safe way
@@ -189,6 +244,7 @@ class CallbackHandler : public fge::Subscription
 {
 public:
     using CalleePtr = CalleeUniquePtr<void, Types...>;
+    using StaticHelpers = CallbackStaticHelpers<void, CalleePtr, Types...>;
 
     CallbackHandler() = default;
     ~CallbackHandler() override = default;
@@ -366,6 +422,7 @@ class UniqueCallbackHandler : public fge::UniqueSubscription
 {
 public:
     using CalleePtr = CalleeUniquePtr<void, Types...>;
+    using StaticHelpers = CallbackStaticHelpers<void, CalleePtr, Types...>;
 
     UniqueCallbackHandler() = default;
     ~UniqueCallbackHandler() override = default;
@@ -498,61 +555,6 @@ private:
     CalleeData g_callee{nullptr, nullptr};
 
     mutable std::recursive_mutex g_mutex;
-};
-
-/**
- * \struct CallbackStaticHelpers
- * \ingroup callback
- * \brief This struct helper is used to create callbacks
- *
- * \tparam TCalleePtr The callback pointer type, can be CalleeUniquePtr or CalleeSharedPtr
- * \tparam Types The list of arguments types passed to the functor
- */
-template<class TReturn, class TCalleePtr, class... Types>
-struct CallbackStaticHelpers
-{
-    using CalleePtr = TCalleePtr;
-
-    /**
-     * \brief Helper function to create a new callback functor
-     *
-     * \param func The callback function
-     * \return The callback pointer
-     */
-    [[nodiscard]] inline static CalleePtr
-    newFunctor(typename fge::CallbackFunctor<TReturn, Types...>::CallbackFunction func)
-    {
-        return CalleePtr{new fge::CallbackFunctor<TReturn, Types...>(func)};
-    }
-
-    /**
-     * \brief Helper function to create a new callback lambda
-     *
-     * \tparam TLambda The lambda type
-     * \param lambda The callback lambda
-     * \return The callback pointer
-     */
-    template<typename TLambda>
-    [[nodiscard]] inline static CalleePtr newLambda(TLambda const& lambda)
-    {
-        return CalleePtr{new fge::CallbackLambda<TReturn, Types...>(lambda)};
-    }
-
-    /**
-     * \brief Helper function to create a new callback object functor
-     *
-     * \tparam TObject The object type
-     * \param func The callback method of the object
-     * \param object The object pointer
-     * \return The callback pointer
-     */
-    template<class TObject>
-    [[nodiscard]] inline static CalleePtr
-    newObjectFunctor(typename fge::CallbackObjectFunctor<TReturn, TObject, Types...>::CallbackFunctionObject func,
-                     TObject* object)
-    {
-        return CalleePtr{new fge::CallbackObjectFunctor<TReturn, TObject, Types...>(func, object)};
-    }
 };
 
 } // namespace fge

--- a/includes/FastEngine/C_callback.inl
+++ b/includes/FastEngine/C_callback.inl
@@ -288,7 +288,8 @@ void UniqueCallbackHandler<Types...>::clear()
 }
 
 template<class... Types>
-fge::CallbackBase<Types...>* UniqueCallbackHandler<Types...>::set(CalleePtr&& callback, fge::Subscriber* subscriber)
+fge::CallbackBase<void, Types...>* UniqueCallbackHandler<Types...>::set(CalleePtr&& callback,
+                                                                        fge::Subscriber* subscriber)
 {
     std::scoped_lock<std::recursive_mutex> const lck(this->g_mutex);
 
@@ -303,30 +304,30 @@ fge::CallbackBase<Types...>* UniqueCallbackHandler<Types...>::set(CalleePtr&& ca
     return this->g_callee._f.get();
 }
 template<class... Types>
-inline fge::CallbackFunctor<Types...>*
-UniqueCallbackHandler<Types...>::setFunctor(typename fge::CallbackFunctor<Types...>::CallbackFunction func,
-                                      fge::Subscriber* subscriber)
+inline fge::CallbackFunctor<void, Types...>*
+UniqueCallbackHandler<Types...>::setFunctor(typename fge::CallbackFunctor<void, Types...>::CallbackFunction func,
+                                            fge::Subscriber* subscriber)
 {
-    return reinterpret_cast<fge::CallbackFunctor<Types...>*>(
-            this->set(std::make_unique<fge::CallbackFunctor<Types...>>(func), subscriber));
+    return reinterpret_cast<fge::CallbackFunctor<void, Types...>*>(
+            this->set(std::make_unique<fge::CallbackFunctor<void, Types...>>(func), subscriber));
 }
 template<class... Types>
 template<typename TLambda>
-inline fge::CallbackLambda<Types...>* UniqueCallbackHandler<Types...>::setLambda(TLambda const& lambda,
-                                                                           fge::Subscriber* subscriber)
+inline fge::CallbackLambda<void, Types...>* UniqueCallbackHandler<Types...>::setLambda(TLambda const& lambda,
+                                                                                       fge::Subscriber* subscriber)
 {
-    return reinterpret_cast<fge::CallbackLambda<Types...>*>(
-            this->set(std::make_unique<fge::CallbackLambda<Types...>>(lambda), subscriber));
+    return reinterpret_cast<fge::CallbackLambda<void, Types...>*>(
+            this->set(std::make_unique<fge::CallbackLambda<void, Types...>>(lambda), subscriber));
 }
 template<class... Types>
 template<class TObject>
-inline fge::CallbackObjectFunctor<TObject, Types...>* UniqueCallbackHandler<Types...>::setObjectFunctor(
-        typename fge::CallbackObjectFunctor<TObject, Types...>::CallbackFunctionObject func,
+inline fge::CallbackObjectFunctor<void, TObject, Types...>* UniqueCallbackHandler<Types...>::setObjectFunctor(
+        typename fge::CallbackObjectFunctor<void, TObject, Types...>::CallbackFunctionObject func,
         TObject* object,
         Subscriber* subscriber)
 {
-    return reinterpret_cast<fge::CallbackObjectFunctor<TObject, Types...>*>(
-            this->set(std::make_unique<fge::CallbackObjectFunctor<TObject, Types...>>(func, object), subscriber));
+    return reinterpret_cast<fge::CallbackObjectFunctor<void, TObject, Types...>*>(
+            this->set(std::make_unique<fge::CallbackObjectFunctor<void, TObject, Types...>>(func, object), subscriber));
 }
 
 template<class... Types>

--- a/includes/FastEngine/C_callback.inl
+++ b/includes/FastEngine/C_callback.inl
@@ -136,7 +136,7 @@ CallbackHandler<Types...>::addFunctor(typename fge::CallbackFunctor<void, Types.
                                       fge::Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackFunctor<void, Types...>*>(
-            this->add(std::make_unique<fge::CallbackFunctor<void, Types...>>(func), subscriber));
+            this->add(StaticHelpers::newFunctor(func), subscriber));
 }
 template<class... Types>
 template<typename TLambda>
@@ -144,7 +144,7 @@ inline fge::CallbackLambda<void, Types...>* CallbackHandler<Types...>::addLambda
                                                                                  fge::Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackLambda<void, Types...>*>(
-            this->add(std::make_unique<fge::CallbackLambda<void, Types...>>(lambda), subscriber));
+            this->add(StaticHelpers::newLambda(lambda), subscriber));
 }
 template<class... Types>
 template<class TObject>
@@ -154,7 +154,7 @@ inline fge::CallbackObjectFunctor<void, TObject, Types...>* CallbackHandler<Type
         Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackObjectFunctor<void, TObject, Types...>*>(
-            this->add(std::make_unique<fge::CallbackObjectFunctor<void, TObject, Types...>>(func, object), subscriber));
+            this->add(StaticHelpers::newObjectFunctor(func, object), subscriber));
 }
 
 template<class... Types>
@@ -309,7 +309,7 @@ UniqueCallbackHandler<Types...>::setFunctor(typename fge::CallbackFunctor<void, 
                                             fge::Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackFunctor<void, Types...>*>(
-            this->set(std::make_unique<fge::CallbackFunctor<void, Types...>>(func), subscriber));
+            this->set(StaticHelpers::newFunctor(func), subscriber));
 }
 template<class... Types>
 template<typename TLambda>
@@ -317,7 +317,7 @@ inline fge::CallbackLambda<void, Types...>* UniqueCallbackHandler<Types...>::set
                                                                                        fge::Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackLambda<void, Types...>*>(
-            this->set(std::make_unique<fge::CallbackLambda<void, Types...>>(lambda), subscriber));
+            this->set(StaticHelpers::newLambda(lambda), subscriber));
 }
 template<class... Types>
 template<class TObject>
@@ -327,7 +327,7 @@ inline fge::CallbackObjectFunctor<void, TObject, Types...>* UniqueCallbackHandle
         Subscriber* subscriber)
 {
     return reinterpret_cast<fge::CallbackObjectFunctor<void, TObject, Types...>*>(
-            this->set(std::make_unique<fge::CallbackObjectFunctor<void, TObject, Types...>>(func, object), subscriber));
+            this->set(StaticHelpers::newObjectFunctor(func, object), subscriber));
 }
 
 template<class... Types>

--- a/includes/FastEngine/network/C_server.hpp
+++ b/includes/FastEngine/network/C_server.hpp
@@ -86,16 +86,17 @@ public:
 
     mutable UniqueCallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&>
             _onClientReturnPacket;
-    mutable CallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&> _onClientReturnEvent;
-    mutable CallbackHandler<ClientSharedPtr const&, Identity const&, uint16_t> _onClientSimpleReturnEvent;
-    mutable CallbackHandler<ClientSharedPtr const&,
-                            Identity const&,
-                            uint16_t,
-                            ObjectSid,
-                            ObjectSid,
-                            ReceivedPacketPtr const&>
+    mutable UniqueCallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&>
+            _onClientReturnEvent;
+    mutable UniqueCallbackHandler<ClientSharedPtr const&, Identity const&, uint16_t> _onClientSimpleReturnEvent;
+    mutable UniqueCallbackHandler<ClientSharedPtr const&,
+                                  Identity const&,
+                                  uint16_t,
+                                  ObjectSid,
+                                  ObjectSid,
+                                  ReceivedPacketPtr const&>
             _onClientObjectReturnEvent;
-    mutable CallbackHandler<ClientSharedPtr const&, Identity const&> _onClientAskFullUpdate;
+    mutable UniqueCallbackHandler<ClientSharedPtr const&, Identity const&> _onClientAskFullUpdate;
 };
 
 /**

--- a/includes/FastEngine/network/C_server.hpp
+++ b/includes/FastEngine/network/C_server.hpp
@@ -84,7 +84,8 @@ public:
     [[nodiscard]] std::optional<Error>
     handleReturnPacket(ClientSharedPtr const& refClient, ClientContext& clientContext, ReceivedPacketPtr& packet) const;
 
-    mutable CallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&> _onClientReturnPacket;
+    mutable UniqueCallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&>
+            _onClientReturnPacket;
     mutable CallbackHandler<ClientSharedPtr const&, Identity const&, ReceivedPacketPtr const&> _onClientReturnEvent;
     mutable CallbackHandler<ClientSharedPtr const&, Identity const&, uint16_t> _onClientSimpleReturnEvent;
     mutable CallbackHandler<ClientSharedPtr const&,

--- a/sources/C_subscription.cpp
+++ b/sources/C_subscription.cpp
@@ -20,6 +20,7 @@ namespace fge
 {
 
 //Subscription
+
 Subscription::Subscription(fge::Subscription&& r) noexcept :
         g_subData(std::move(r.g_subData))
 {
@@ -136,6 +137,121 @@ fge::Subscription::SubscriberCount Subscription::getCount(fge::Subscriber* subsc
     return 0;
 }
 
+//UniqueSubscription
+
+UniqueSubscription::UniqueSubscription(fge::UniqueSubscription&& r) noexcept :
+        g_subscriber(r.g_subscriber)
+{
+    if (this->g_subscriber != nullptr)
+    {
+        this->g_subscriber->detachSilent(&r);
+        this->g_subscriber->attachSilent(this);
+        r.g_subscriber = nullptr;
+    }
+}
+
+fge::UniqueSubscription& UniqueSubscription::operator=(fge::UniqueSubscription&& r) noexcept
+{
+    this->detachAll();
+    this->g_subscriber = r.g_subscriber;
+    if (this->g_subscriber != nullptr)
+    {
+        this->g_subscriber->detachSilent(&r);
+        this->g_subscriber->attachSilent(this);
+    }
+    return *this;
+}
+
+void UniqueSubscription::detachAll()
+{
+    if (this->g_subscriber != nullptr)
+    {
+        this->g_subscriber->detachSilent(this);
+        this->g_subscriber = nullptr;
+    }
+}
+
+void UniqueSubscription::detachSilent(fge::Subscriber* subscriber)
+{
+    if (subscriber == nullptr || this->g_subscriber != subscriber)
+    {
+        return;
+    }
+
+    this->onDetach(subscriber);
+    this->g_subscriber = nullptr;
+}
+
+bool UniqueSubscription::detach(fge::Subscriber* subscriber)
+{
+    if (subscriber == nullptr)
+    {
+        return true;
+    }
+
+    if (this->g_subscriber != subscriber)
+    {
+        return false;
+    }
+
+    subscriber->detachSilent(this);
+    this->g_subscriber = nullptr;
+    return true;
+}
+fge::UniqueSubscription::SubscriberCount UniqueSubscription::detachOnce(fge::Subscriber* subscriber)
+{
+    if (subscriber == nullptr)
+    {
+        return 1;
+    }
+
+    if (this->g_subscriber != subscriber)
+    {
+        return 0;
+    }
+
+    subscriber->detachSilent(this);
+    this->g_subscriber = nullptr;
+    return 0;
+}
+
+fge::UniqueSubscription::SubscriberCount UniqueSubscription::attach(fge::Subscriber* subscriber)
+{
+    if (subscriber == nullptr)
+    {
+        return 1;
+    }
+
+    if (subscriber == this->g_subscriber)
+    {
+        return 1;
+    }
+
+    if (this->g_subscriber != nullptr)
+    {
+        return 0;
+    }
+
+    this->g_subscriber = subscriber;
+    subscriber->attachSilent(this);
+    return 1;
+}
+
+fge::UniqueSubscription::SubscriberCount UniqueSubscription::getCount(fge::Subscriber* subscriber) const
+{
+    if (subscriber == nullptr || this->g_subscriber == nullptr)
+    {
+        return 0;
+    }
+
+    if (subscriber != this->g_subscriber)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
 //Subscriber
 void Subscriber::detachAll()
 {
@@ -145,21 +261,21 @@ void Subscriber::detachAll()
     }
     this->g_subData.clear();
 }
-void Subscriber::detachSilent(fge::Subscription* subscription)
+void Subscriber::detachSilent(fge::BaseSubscription* subscription)
 {
     if (this->g_subData.erase(subscription) > 0)
     {
         this->onDetach(subscription);
     }
 }
-void Subscriber::detach(fge::Subscription* subscription)
+void Subscriber::detach(fge::BaseSubscription* subscription)
 {
     if (this->g_subData.erase(subscription) > 0)
     {
         subscription->detachSilent(this);
     }
 }
-void Subscriber::attachSilent(fge::Subscription* subscription)
+void Subscriber::attachSilent(fge::BaseSubscription* subscription)
 {
     this->g_subData.insert(subscription);
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the callback and subscription system, enhancing flexibility, clarity, and type safety. The main changes include the addition of a unique callback handler class, and a refactoring of the subscription base class to support both multi-subscriber and unique-subscriber models. These updates make it easier to manage callbacks and their lifetimes, and to distinguish between single and multiple subscriber scenarios.

Callback System Enhancements:

* Updated `CallbackHandler` to use `CallbackStaticHelpers` for callback creation, simplifying the implementation and making callback addition more consistent. (`includes/FastEngine/C_callback.hpp`, `includes/FastEngine/C_callback.inl`) [[1]](diffhunk://#diff-efdbd46484a6d8111e3fdb30f241a71c474779eff71107f223b7b77fd26f7b51R247) [[2]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL139-R147) [[3]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bL157-R157)

Unique Callback Handler:

* Introduced `UniqueCallbackHandler`, a class designed for scenarios where only one callback is needed. This class provides methods to set, remove, and call a single callback, and manages its subscriber explicitly. (`includes/FastEngine/C_callback.hpp`, `includes/FastEngine/C_callback.inl`) [[1]](diffhunk://#diff-efdbd46484a6d8111e3fdb30f241a71c474779eff71107f223b7b77fd26f7b51L356-R557) [[2]](diffhunk://#diff-c3ff927c13c315cdf3b7e1232e3ee564ecda24e3319c9250fa7026a6e4ba483bR280-R400)
* Updated usage in client code to use `setLambda` instead of `addLambda` for unique callback scenarios, reflecting the new API. (`examples/clientServerLifeSimulator_004/server/main.cpp`)

Subscription System Refactor:

* Refactored the subscription base class, introducing `BaseSubscription` as an abstract base, and splitting into `Subscription` (multi-subscriber) and `UniqueSubscription` (single-subscriber) classes. This clarifies the intent and usage of each subscription type and improves type safety. (`includes/FastEngine/C_subscription.hpp`) [[1]](diffhunk://#diff-d3c597272aa0b19863c8046aefef0d8f8900a675b7f46b95c3f1578c5e4dea49L30-R36) [[2]](diffhunk://#diff-d3c597272aa0b19863c8046aefef0d8f8900a675b7f46b95c3f1578c5e4dea49L80-R51) [[3]](diffhunk://#diff-d3c597272aa0b19863c8046aefef0d8f8900a675b7f46b95c3f1578c5e4dea49L90-R72) [[4]](diffhunk://#diff-d3c597272aa0b19863c8046aefef0d8f8900a675b7f46b95c3f1578c5e4dea49L112-R198)

These changes collectively modernize the callback and subscription infrastructure, making it easier for developers to implement and maintain callback-based features with clear subscriber management.